### PR TITLE
Add xml and json output format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.so
 *.dylib
 
+# macOS
+.DS_Store
+
 # Generated Files
 Local_Release
 Documentation/html

--- a/tools/eventlist/README.md
+++ b/tools/eventlist/README.md
@@ -9,13 +9,14 @@ Usage:
   eventlist [-I <scvdFile>]... [-o <outputFile>] [-a <elf/axfFile>] [-b] <logFile>
 
 Flags:
-  -a <fileName>   elf/axf file name
-  -b --begin      show statistic at beginning
-  -h --help       show short help
-  -I <fileName>   include SCVD file name
-  -o <fileName>   output file name
-  -s --statistic  show statistic only
-  -V --version    show version info
+  -a <fileName>     elf/axf file name
+  -b --begin        show statistic at beginning
+  -f <txt/xml/json> output format, default: txt
+  -h --help         show short help
+  -I <fileName>     include SCVD file name
+  -o <fileName>     output file name
+  -s --statistic    show statistic only
+  -V --version      show version info
 ```
 
 ## Building the tool locally

--- a/tools/eventlist/cmd/eventlist/main.go
+++ b/tools/eventlist/cmd/eventlist/main.go
@@ -115,12 +115,14 @@ func main() {
 		infoOpt(commFlag, "o", "", "<fileName>")
 		infoOpt(commFlag, "s", "statistic", "")
 		infoOpt(commFlag, "V", "version", "")
+		infoOpt(commFlag, "f", "format", "<formatType>")
 		usage = true
 	}
 	// parse command line
 	commFlag.Var(&paths, "I", "include SCVD file name")
 	outputFile := commFlag.String("o", "", "output file name")
 	elfFile := commFlag.String("a", "", "elf/axf file name")
+	formatType := commFlag.String("f", "", "format type: txt, json, xml")
 	var statBegin bool
 	commFlag.BoolVar(&statBegin, "b", false, "show statistic at beginning")
 	commFlag.BoolVar(&statBegin, "begin", false, "show statistic at beginning")
@@ -169,7 +171,7 @@ func main() {
 		return
 	}
 
-	if err := output.Print(outputFile, &eventFile[0], evdefs, typedefs, statBegin, showStatistic); err != nil {
+	if err := output.Print(outputFile, formatType, &eventFile[0], evdefs, typedefs, statBegin, showStatistic); err != nil {
 		fmt.Print(Progname + ": ")
 		fmt.Println(err)
 	}

--- a/tools/eventlist/pkg/output/output.go
+++ b/tools/eventlist/pkg/output/output.go
@@ -20,6 +20,9 @@ package output
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"eventlist/pkg/eval"
 	"eventlist/pkg/event"
@@ -32,6 +35,7 @@ import (
 var errNoEvents = errors.New("cannot open event file")
 
 var TimeFactor *float64
+var FormatType string = "txt"
 
 func TimeInSecs(time uint64) float64 {
 	if TimeFactor == nil {
@@ -60,6 +64,43 @@ type eventStatistic struct {
 	textMinE  string
 	textMaxB  string
 	textMaxE  string
+}
+
+type EventRecord struct {
+	Index         int     `json:"index" xml:"index"`
+	Time          float64 `json:"time" xml:"time"`
+	Component     string  `json:"component" xml:"component"`
+	EventProperty string  `json:"eventProperty" xml:"eventProperty"`
+	Value         string  `json:"value" xml:"value"`
+}
+
+type EventRecordStatistic struct {
+	Event       string  `json:"event" xml:"event"`
+	Count       int     `json:"count" xml:"count"`
+	AddCount    string  `json:"addCount" xml:"addCount"`
+	Start       string  `json:"start" xml:"start"`
+	MinStopTime float64 `json:"minStopTime" xml:"minStopTime"`
+	MaxStopTime float64 `json:"maxStopTime" xml:"maxStopTime"`
+	Total       string  `json:"total" xml:"total"`
+	Min         string  `json:"min" xml:"min"`
+	Max         string  `json:"max" xml:"max"`
+	First       string  `json:"first" xml:"first"`
+	Last        string  `json:"last" xml:"last"`
+	Avg         string  `json:"avg" xml:"avg"`
+	MinTime     float64 `json:"minTime" xml:"minTime"`
+	MaxTime     float64 `json:"maxTime" xml:"maxTime"`
+	FirstTime   string  `json:"firstTime" xml:"firstTime"`
+	LastTime    string  `json:"lastTime" xml:"lastTime"`
+	TextB       string  `json:"textB" xml:"textB"`
+	TextMinB    string  `json:"textMinB" xml:"textMinB"`
+	TextMinE    string  `json:"textMinE" xml:"textMinE"`
+	TextMaxB    string  `json:"textMaxB" xml:"textMaxB"`
+	TextMaxE    string  `json:"textMaxE" xml:"textMaxE"`
+}
+
+type EventsTable struct {
+	Events     []EventRecord          `json:"events" xml:"events"`
+	Statistics []EventRecordStatistic `json:"statistics" xml:"statistics"`
 }
 
 func (es *eventStatistic) init() {
@@ -279,60 +320,87 @@ func (o *Output) buildStatistic(in *bufio.Reader, evdefs map[uint16]scvd.Event,
 	return eventCount
 }
 
-func (o *Output) printStatistic(out *bufio.Writer, eventCount int) error {
+func write(out *bufio.Writer, format string, a ...any) (n int, err error) {
+	if FormatType == "txt" {
+		return fmt.Fprintf(out, format, a...)
+	}
+	return 0, nil
+}
+
+func (o *Output) printStatistic(out *bufio.Writer, eventCount int, eventTable *EventsTable) error {
 	var err error
 
 	if out != nil && eventCount > 0 {
-		if _, err = out.WriteString("   Start/Stop event statistic\n"); err != nil {
+		if _, err = write(out, "   Start/Stop event statistic\n"); err != nil {
 			return err
 		}
-		if _, err = out.WriteString("   --------------------------\n\n"); err != nil {
+		if _, err = write(out, "   --------------------------\n\n"); err != nil {
 			return err
 		}
-		if _, err = out.WriteString("Event count      total       min         max         average     first       last\n"); err != nil {
+		if _, err = write(out, "Event count      total       min         max         average     first       last\n"); err != nil {
 			return err
 		}
-		if _, err = out.WriteString("----- -----      -----       ---         ---         -------     -----       ----\n"); err != nil {
+		if _, err = write(out, "----- -----      -----       ---         ---         -------     -----       ----\n"); err != nil {
 			return err
 		}
 		for i := uint16(0); i < uint16(len(o.evProps)); i++ {
 			for j := uint16(0); j < uint16(len(o.evProps[i].values)); j++ {
 				if o.evProps[i].values[j].evFirst {
-					_, err = fmt.Fprintf(out, "%c(%d)", byte(i+'A'), j)
+					eventStat := EventRecordStatistic{
+						Event:       fmt.Sprintf("%c(%d)", byte(i+'A'), j),
+						AddCount:    o.evProps[i].getAddCount(j),
+						Count:       o.evProps[i].getCount(j),
+						Total:       o.evProps[i].getTot(j),
+						Min:         o.evProps[i].getMin(j),
+						Max:         o.evProps[i].getMax(j),
+						Avg:         o.evProps[i].getAvg(j),
+						First:       o.evProps[i].getFirst(j),
+						Last:        o.evProps[i].getLast(j),
+						MinTime:     o.evProps[i].values[j].minTime,
+						TextMinB:    o.evProps[i].values[j].textMinB,
+						TextMinE:    o.evProps[i].values[j].textMinE,
+						MinStopTime: o.evProps[i].values[j].minTime + o.evProps[i].values[j].min,
+						MaxStopTime: o.evProps[i].values[j].maxTime + o.evProps[i].values[j].max,
+						MaxTime:     o.evProps[i].values[j].maxTime,
+						TextMaxB:    o.evProps[i].values[j].textMaxB,
+						TextMaxE:    o.evProps[i].values[j].textMaxE,
+					}
+					_, err = write(out, eventStat.Event)
 					if err == nil && j < 10 {
-						err = out.WriteByte(' ')
+						_, err = write(out, " ")
 					}
 					if err != nil {
 						return err
 					}
-					_, err = fmt.Fprintf(out, " %5d%s %s %s %s %s %s %s\n",
-						o.evProps[i].getCount(j),
-						o.evProps[i].getAddCount(j),
-						o.evProps[i].getTot(j),
-						o.evProps[i].getMin(j),
-						o.evProps[i].getMax(j),
-						o.evProps[i].getAvg(j),
-						o.evProps[i].getFirst(j),
-						o.evProps[i].getLast(j))
+					_, err = write(out, " %5d%s %s %s %s %s %s %s\n",
+						eventStat.Count,
+						eventStat.AddCount,
+						eventStat.Total,
+						eventStat.Min,
+						eventStat.Max,
+						eventStat.Avg,
+						eventStat.First,
+						eventStat.Last)
 					if err != nil {
 						return err
 					}
-					_, err = fmt.Fprintf(out, "      Min: Start: %.8f %s Stop: %.8f %s\n",
-						o.evProps[i].values[j].minTime,
-						o.evProps[i].values[j].textMinB,
-						o.evProps[i].values[j].minTime+o.evProps[i].values[j].min,
-						o.evProps[i].values[j].textMinE)
+					_, err = write(out, "      Min: Start: %.8f %s Stop: %.8f %s\n",
+						eventStat.MinTime,
+						eventStat.TextMinB,
+						eventStat.MinStopTime,
+						eventStat.TextMinE)
 					if err != nil {
 						return err
 					}
-					_, err = fmt.Fprintf(out, "      Max: Start: %.8f %s Stop: %.8f %s\n\n",
-						o.evProps[i].values[j].maxTime,
-						o.evProps[i].values[j].textMaxB,
-						o.evProps[i].values[j].maxTime+o.evProps[i].values[j].max,
-						o.evProps[i].values[j].textMaxE)
+					_, err = write(out, "      Max: Start: %.8f %s Stop: %.8f %s\n\n",
+						eventStat.MaxTime,
+						eventStat.TextMaxB,
+						eventStat.MaxStopTime,
+						eventStat.TextMaxE)
 					if err != nil {
 						return err
 					}
+					eventTable.Statistics = append(eventTable.Statistics, eventStat)
 				}
 			}
 		}
@@ -376,7 +444,7 @@ func escapeGen(s string) string {
 }
 
 func (o *Output) printEvents(out *bufio.Writer, in *bufio.Reader, evdefs map[uint16]scvd.Event,
-	typedefs map[string]map[string]map[int16]string) error {
+	typedefs map[string]map[string]map[int16]string, eventTable *EventsTable) error {
 	if out == nil || in == nil {
 		return nil
 	}
@@ -416,36 +484,49 @@ func (o *Output) printEvents(out *bufio.Writer, in *bufio.Reader, evdefs map[uin
 				*TimeFactor = 1.0 / float64(ev.Value1)
 			}
 		}
+		eventRecord := EventRecord{
+			Index: no,
+			Time:  beforeClockEvent + TimeInSecs(ev.Time-lastClockEvent),
+		}
 		var rep string
 		if evdef, ok := evdefs[ev.Info.ID]; ok {
+			eventRecord.Component = evdef.Brief
+			eventRecord.EventProperty = evdef.Property
 			if ev.Info.ID == 0xFE00 && ev.Data != nil { // special case stdout
 				s := escapeGen(string(*ev.Data))
-				_, err = fmt.Fprintf(out, "%5d %.8f %*s %*s \"%s\"\n",
-					no, beforeClockEvent+TimeInSecs(ev.Time-lastClockEvent),
-					-o.componentSize, evdef.Brief, -o.propertySize, evdef.Property, s)
+				eventRecord.Value = s
+				_, err = write(out, "%5d %.8f %*s %*s \"%s\"\n",
+					eventRecord.Index, eventRecord.Time, -o.componentSize,
+					eventRecord.Component, -o.propertySize, eventRecord.EventProperty, eventRecord.Value)
 			} else {
 				rep, err = ev.EvalLine(evdef, typedefs)
 				if err == nil {
-					_, err = fmt.Fprintf(out, "%5d %.8f %*s %*s %s\n",
-						no, beforeClockEvent+TimeInSecs(ev.Time-lastClockEvent),
-						-o.componentSize, evdef.Brief, -o.propertySize, evdef.Property, rep)
+					eventRecord.Value = rep
+					_, err = write(out, "%5d %.8f %*s %*s %s\n",
+						eventRecord.Index, eventRecord.Time, -o.componentSize,
+						eventRecord.Component, -o.propertySize, eventRecord.EventProperty, eventRecord.Value)
 				}
 			}
 		} else {
+			eventRecord.Component = fmt.Sprintf("0x%02X%*s", uint8(ev.Info.ID>>8), -(o.componentSize - 4), "")
+			eventRecord.EventProperty = fmt.Sprintf("0x%04X%*s", ev.Info.ID, -(o.propertySize - 6), "")
 			if ev.Info.ID == 0xFE00 && ev.Data != nil { // special case stdout
 				s := escapeGen(string(*ev.Data))
-				_, err = fmt.Fprintf(out, "%5d %.8f 0x%02X%*s 0x%04X%*s \"%s\"\n",
-					no, beforeClockEvent+TimeInSecs(ev.Time-lastClockEvent),
+				eventRecord.Value = s
+				_, err = write(out, "%5d %.8f 0x%02X%*s 0x%04X%*s \"%s\"\n",
+					eventRecord.Index, eventRecord.Time,
 					uint8(ev.Info.ID>>8), -(o.componentSize - 4), "",
-					ev.Info.ID, -(o.propertySize - 6), "", s)
+					ev.Info.ID, -(o.propertySize - 6), "", eventRecord.Value)
 			} else {
 				rep = ev.GetValuesAsString()
-				_, err = fmt.Fprintf(out, "%5d %.8f 0x%02X%*s 0x%04X%*s %s\n",
-					no, beforeClockEvent+TimeInSecs(ev.Time-lastClockEvent),
+				eventRecord.Value = rep
+				_, err = write(out, "%5d %.8f 0x%02X%*s 0x%04X%*s %s\n",
+					eventRecord.Index, eventRecord.Time,
 					uint8(ev.Info.ID>>8), -(o.componentSize - 4), "",
-					ev.Info.ID, -(o.propertySize - 6), "", rep)
+					ev.Info.ID, -(o.propertySize - 6), "", eventRecord.Value)
 			}
 		}
+		eventTable.Events = append(eventTable.Events, eventRecord)
 		if err != nil {
 			break
 		}
@@ -456,24 +537,24 @@ func (o *Output) printEvents(out *bufio.Writer, in *bufio.Reader, evdefs map[uin
 
 func (o *Output) printHeader(out *bufio.Writer) error {
 	var err error
-	if _, err = out.WriteString("   Detailed event list\n"); err != nil {
+	if _, err = write(out, "   Detailed event list\n"); err != nil {
 		return err
 	}
-	if _, err = out.WriteString("   -------------------\n\n"); err != nil {
+	if _, err = write(out, "   -------------------\n\n"); err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(out, "%5s %-10s %*s %*s %s\n", o.columns[0], o.columns[1],
+	_, err = write(out, "%5s %-10s %*s %*s %s\n", o.columns[0], o.columns[1],
 		-o.componentSize, o.columns[2], -o.propertySize, o.columns[3], o.columns[4])
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(out, "----- --------   %*s %*s -----\n",
+	_, err = write(out, "----- --------   %*s %*s -----\n",
 		-o.componentSize, "---------", -o.propertySize, "--------------")
 	return err
 }
 
 func (o *Output) print(out *bufio.Writer, eventFile *string, evdefs map[uint16]scvd.Event,
-	typedefs map[string]map[string]map[int16]string, statBegin bool, showStatistic bool) error {
+	typedefs map[string]map[string]map[int16]string, statBegin bool, showStatistic bool, eventsTable *EventsTable) error {
 	var b event.Binary
 	var err error
 	var eventCount int
@@ -492,9 +573,9 @@ func (o *Output) print(out *bufio.Writer, eventFile *string, evdefs map[uint16]s
 	}
 
 	if err == nil && statBegin {
-		err = o.printStatistic(out, eventCount)
+		err = o.printStatistic(out, eventCount, eventsTable)
 		if err == nil && !showStatistic {
-			_, err = out.WriteString("\n")
+			_, err = write(out, "\n")
 		}
 	}
 
@@ -503,7 +584,7 @@ func (o *Output) print(out *bufio.Writer, eventFile *string, evdefs map[uint16]s
 		if err == nil {
 			in = b.Open(eventFile)
 			if in != nil {
-				err = o.printEvents(out, in, evdefs, typedefs)
+				err = o.printEvents(out, in, evdefs, typedefs, eventsTable)
 				if err != nil {
 					_ = b.Close()
 				} else {
@@ -517,30 +598,39 @@ func (o *Output) print(out *bufio.Writer, eventFile *string, evdefs map[uint16]s
 
 	if err == nil && !statBegin {
 		if !showStatistic {
-			_, err = out.WriteString("\n")
+			_, err = write(out, "\n")
 		}
 		if err == nil {
-			err = o.printStatistic(out, eventCount)
+			err = o.printStatistic(out, eventCount, eventsTable)
 		}
 	}
-
 	if err == nil {
 		err = out.Flush()
 	}
 	return err
 }
 
-func Print(filename *string, eventFile *string, evdefs map[uint16]scvd.Event,
+func Print(filename *string, formatType *string, eventFile *string, evdefs map[uint16]scvd.Event,
 	typedefs map[string]map[string]map[int16]string, statBegin bool, showStatistic bool) error {
 	var file *os.File
 	var err error
 	var o Output
+
+	eventsTable := EventsTable{
+		Events:     []EventRecord{},
+		Statistics: []EventRecordStatistic{},
+	}
 
 	if TimeFactor == nil {
 		TimeFactor = new(float64)
 	}
 	if *TimeFactor == 0.0 {
 		*TimeFactor = 4e-8
+	}
+	if formatType != nil {
+		if *formatType == "xml" || *formatType == "json" {
+			FormatType = *formatType
+		}
 	}
 
 	if filename != nil && len(*filename) != 0 {
@@ -553,9 +643,29 @@ func Print(filename *string, eventFile *string, evdefs map[uint16]scvd.Event,
 	}
 
 	out := bufio.NewWriter(file)
-	err = o.print(out, eventFile, evdefs, typedefs, statBegin, showStatistic)
+	err = o.print(out, eventFile, evdefs, typedefs, statBegin, showStatistic, &eventsTable)
 	if err == nil {
-		err = out.Flush()
+		if FormatType == "json" {
+			output, err := json.Marshal(eventsTable)
+			if err == nil {
+				buf := bytes.NewBuffer(output)
+				_, err = fmt.Fprint(out, buf)
+				if err == nil {
+					err = out.Flush()
+				}
+			}
+		} else if FormatType == "xml" {
+			output, err := xml.Marshal(eventsTable)
+			if err == nil {
+				buf := bytes.NewBuffer(output)
+				_, err = fmt.Fprint(out, buf)
+				if err == nil {
+					err = out.Flush()
+				}
+			}
+		} else {
+			err = out.Flush()
+		}
 	} else {
 		_ = out.Flush()
 	}

--- a/tools/eventlist/pkg/output/output.go
+++ b/tools/eventlist/pkg/output/output.go
@@ -508,8 +508,8 @@ func (o *Output) printEvents(out *bufio.Writer, in *bufio.Reader, evdefs map[uin
 				}
 			}
 		} else {
-			eventRecord.Component = fmt.Sprintf("0x%02X%*s", uint8(ev.Info.ID>>8), -(o.componentSize - 4), "")
-			eventRecord.EventProperty = fmt.Sprintf("0x%04X%*s", ev.Info.ID, -(o.propertySize - 6), "")
+			eventRecord.Component = fmt.Sprintf("0x%02X%*s", uint8(ev.Info.ID>>8), 0, "")
+			eventRecord.EventProperty = fmt.Sprintf("0x%04X%*s", ev.Info.ID, 0, "")
 			if ev.Info.ID == 0xFE00 && ev.Data != nil { // special case stdout
 				s := escapeGen(string(*ev.Data))
 				eventRecord.Value = s

--- a/tools/eventlist/pkg/output/output.go
+++ b/tools/eventlist/pkg/output/output.go
@@ -320,7 +320,7 @@ func (o *Output) buildStatistic(in *bufio.Reader, evdefs map[uint16]scvd.Event,
 	return eventCount
 }
 
-func write(out *bufio.Writer, format string, a ...any) (n int, err error) {
+func conditionalWrite(out *bufio.Writer, format string, a ...any) (n int, err error) {
 	if FormatType == "txt" {
 		return fmt.Fprintf(out, format, a...)
 	}
@@ -331,16 +331,16 @@ func (o *Output) printStatistic(out *bufio.Writer, eventCount int, eventTable *E
 	var err error
 
 	if out != nil && eventCount > 0 {
-		if _, err = write(out, "   Start/Stop event statistic\n"); err != nil {
+		if _, err = conditionalWrite(out, "   Start/Stop event statistic\n"); err != nil {
 			return err
 		}
-		if _, err = write(out, "   --------------------------\n\n"); err != nil {
+		if _, err = conditionalWrite(out, "   --------------------------\n\n"); err != nil {
 			return err
 		}
-		if _, err = write(out, "Event count      total       min         max         average     first       last\n"); err != nil {
+		if _, err = conditionalWrite(out, "Event count      total       min         max         average     first       last\n"); err != nil {
 			return err
 		}
-		if _, err = write(out, "----- -----      -----       ---         ---         -------     -----       ----\n"); err != nil {
+		if _, err = conditionalWrite(out, "----- -----      -----       ---         ---         -------     -----       ----\n"); err != nil {
 			return err
 		}
 		for i := uint16(0); i < uint16(len(o.evProps)); i++ {
@@ -365,14 +365,14 @@ func (o *Output) printStatistic(out *bufio.Writer, eventCount int, eventTable *E
 						TextMaxB:    o.evProps[i].values[j].textMaxB,
 						TextMaxE:    o.evProps[i].values[j].textMaxE,
 					}
-					_, err = write(out, eventStat.Event)
+					_, err = conditionalWrite(out, eventStat.Event)
 					if err == nil && j < 10 {
-						_, err = write(out, " ")
+						_, err = conditionalWrite(out, " ")
 					}
 					if err != nil {
 						return err
 					}
-					_, err = write(out, " %5d%s %s %s %s %s %s %s\n",
+					_, err = conditionalWrite(out, " %5d%s %s %s %s %s %s %s\n",
 						eventStat.Count,
 						eventStat.AddCount,
 						eventStat.Total,
@@ -384,7 +384,7 @@ func (o *Output) printStatistic(out *bufio.Writer, eventCount int, eventTable *E
 					if err != nil {
 						return err
 					}
-					_, err = write(out, "      Min: Start: %.8f %s Stop: %.8f %s\n",
+					_, err = conditionalWrite(out, "      Min: Start: %.8f %s Stop: %.8f %s\n",
 						eventStat.MinTime,
 						eventStat.TextMinB,
 						eventStat.MinStopTime,
@@ -392,7 +392,7 @@ func (o *Output) printStatistic(out *bufio.Writer, eventCount int, eventTable *E
 					if err != nil {
 						return err
 					}
-					_, err = write(out, "      Max: Start: %.8f %s Stop: %.8f %s\n\n",
+					_, err = conditionalWrite(out, "      Max: Start: %.8f %s Stop: %.8f %s\n\n",
 						eventStat.MaxTime,
 						eventStat.TextMaxB,
 						eventStat.MaxStopTime,
@@ -495,14 +495,14 @@ func (o *Output) printEvents(out *bufio.Writer, in *bufio.Reader, evdefs map[uin
 			if ev.Info.ID == 0xFE00 && ev.Data != nil { // special case stdout
 				s := escapeGen(string(*ev.Data))
 				eventRecord.Value = s
-				_, err = write(out, "%5d %.8f %*s %*s \"%s\"\n",
+				_, err = conditionalWrite(out, "%5d %.8f %*s %*s \"%s\"\n",
 					eventRecord.Index, eventRecord.Time, -o.componentSize,
 					eventRecord.Component, -o.propertySize, eventRecord.EventProperty, eventRecord.Value)
 			} else {
 				rep, err = ev.EvalLine(evdef, typedefs)
 				if err == nil {
 					eventRecord.Value = rep
-					_, err = write(out, "%5d %.8f %*s %*s %s\n",
+					_, err = conditionalWrite(out, "%5d %.8f %*s %*s %s\n",
 						eventRecord.Index, eventRecord.Time, -o.componentSize,
 						eventRecord.Component, -o.propertySize, eventRecord.EventProperty, eventRecord.Value)
 				}
@@ -513,14 +513,14 @@ func (o *Output) printEvents(out *bufio.Writer, in *bufio.Reader, evdefs map[uin
 			if ev.Info.ID == 0xFE00 && ev.Data != nil { // special case stdout
 				s := escapeGen(string(*ev.Data))
 				eventRecord.Value = s
-				_, err = write(out, "%5d %.8f 0x%02X%*s 0x%04X%*s \"%s\"\n",
+				_, err = conditionalWrite(out, "%5d %.8f 0x%02X%*s 0x%04X%*s \"%s\"\n",
 					eventRecord.Index, eventRecord.Time,
 					uint8(ev.Info.ID>>8), -(o.componentSize - 4), "",
 					ev.Info.ID, -(o.propertySize - 6), "", eventRecord.Value)
 			} else {
 				rep = ev.GetValuesAsString()
 				eventRecord.Value = rep
-				_, err = write(out, "%5d %.8f 0x%02X%*s 0x%04X%*s %s\n",
+				_, err = conditionalWrite(out, "%5d %.8f 0x%02X%*s 0x%04X%*s %s\n",
 					eventRecord.Index, eventRecord.Time,
 					uint8(ev.Info.ID>>8), -(o.componentSize - 4), "",
 					ev.Info.ID, -(o.propertySize - 6), "", eventRecord.Value)
@@ -537,18 +537,18 @@ func (o *Output) printEvents(out *bufio.Writer, in *bufio.Reader, evdefs map[uin
 
 func (o *Output) printHeader(out *bufio.Writer) error {
 	var err error
-	if _, err = write(out, "   Detailed event list\n"); err != nil {
+	if _, err = conditionalWrite(out, "   Detailed event list\n"); err != nil {
 		return err
 	}
-	if _, err = write(out, "   -------------------\n\n"); err != nil {
+	if _, err = conditionalWrite(out, "   -------------------\n\n"); err != nil {
 		return err
 	}
-	_, err = write(out, "%5s %-10s %*s %*s %s\n", o.columns[0], o.columns[1],
+	_, err = conditionalWrite(out, "%5s %-10s %*s %*s %s\n", o.columns[0], o.columns[1],
 		-o.componentSize, o.columns[2], -o.propertySize, o.columns[3], o.columns[4])
 	if err != nil {
 		return err
 	}
-	_, err = write(out, "----- --------   %*s %*s -----\n",
+	_, err = conditionalWrite(out, "----- --------   %*s %*s -----\n",
 		-o.componentSize, "---------", -o.propertySize, "--------------")
 	return err
 }
@@ -575,7 +575,7 @@ func (o *Output) print(out *bufio.Writer, eventFile *string, evdefs map[uint16]s
 	if err == nil && statBegin {
 		err = o.printStatistic(out, eventCount, eventsTable)
 		if err == nil && !showStatistic {
-			_, err = write(out, "\n")
+			_, err = conditionalWrite(out, "\n")
 		}
 	}
 
@@ -598,7 +598,7 @@ func (o *Output) print(out *bufio.Writer, eventFile *string, evdefs map[uint16]s
 
 	if err == nil && !statBegin {
 		if !showStatistic {
-			_, err = write(out, "\n")
+			_, err = conditionalWrite(out, "\n")
 		}
 		if err == nil {
 			err = o.printStatistic(out, eventCount, eventsTable)
@@ -651,7 +651,7 @@ func Print(filename *string, formatType *string, eventFile *string, evdefs map[u
 				buf := bytes.NewBuffer(output)
 				_, err = fmt.Fprint(out, buf)
 				if err == nil {
-					err = out.Flush()
+					out.Flush()
 				}
 			}
 		} else if FormatType == "xml" {
@@ -660,7 +660,7 @@ func Print(filename *string, formatType *string, eventFile *string, evdefs map[u
 				buf := bytes.NewBuffer(output)
 				_, err = fmt.Fprint(out, buf)
 				if err == nil {
-					err = out.Flush()
+					out.Flush()
 				}
 			}
 		} else {

--- a/tools/eventlist/pkg/output/output_test.go
+++ b/tools/eventlist/pkg/output/output_test.go
@@ -574,7 +574,7 @@ func Test_eventProperty_getLast(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
-		Values [16]eventStatistic
+		values [16]eventStatistic
 	}
 	type args struct {
 		idx uint16
@@ -593,7 +593,7 @@ func Test_eventProperty_getLast(t *testing.T) {
 			t.Parallel()
 
 			ep := &eventProperty{
-				values: tt.fields.Values,
+				values: tt.fields.values,
 			}
 			if got := ep.getLast(tt.args.idx); got != tt.want {
 				t.Errorf("eventProperty.getLast() %s = %v, want %v", tt.name, got, tt.want)

--- a/tools/eventlist/pkg/output/output_test.go
+++ b/tools/eventlist/pkg/output/output_test.go
@@ -574,7 +574,7 @@ func Test_eventProperty_getLast(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
-		values [16]eventStatistic
+		Values [16]eventStatistic
 	}
 	type args struct {
 		idx uint16
@@ -593,7 +593,7 @@ func Test_eventProperty_getLast(t *testing.T) {
 			t.Parallel()
 
 			ep := &eventProperty{
-				values: tt.fields.values,
+				values: tt.fields.Values,
 			}
 			if got := ep.getLast(tt.args.idx); got != tt.want {
 				t.Errorf("eventProperty.getLast() %s = %v, want %v", tt.name, got, tt.want)
@@ -701,6 +701,10 @@ func TestOutput_printStatistic(t *testing.T) { //nolint:golint,paralleltest
 		{"header", fields{props0, 15, 20}, args{nil, 1}, header, false},
 		{"line1", fields{props1, 15, 20}, args{nil, 1}, header + line1, false},
 	}
+	eventsTable := EventsTable{
+		Events:     []EventRecord{},
+		Statistics: []EventRecordStatistic{},
+	}
 	for _, tt := range tests { //nolint:golint,paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.out = bufio.NewWriter(&b)
@@ -709,7 +713,7 @@ func TestOutput_printStatistic(t *testing.T) { //nolint:golint,paralleltest
 				componentSize: tt.fields.componentSize,
 				propertySize:  tt.fields.propertySize,
 			}
-			if err := o.printStatistic(tt.args.out, tt.args.eventCount); (err != nil) != tt.wantErr {
+			if err := o.printStatistic(tt.args.out, tt.args.eventCount, &eventsTable); (err != nil) != tt.wantErr {
 				t.Errorf("Output.printStatistic() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			tt.args.out.Flush()
@@ -806,6 +810,10 @@ func TestOutput_printEvents(t *testing.T) { //nolint:golint,paralleltest
 		{"read3", fields{}, args{}, &s11, line3, false},
 		{"readNix", fields{}, args{}, &sNix, "", false},
 	}
+	eventsTable := EventsTable{
+		Events:     []EventRecord{},
+		Statistics: []EventRecordStatistic{},
+	}
 	for _, tt := range tests { //nolint:golint,paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.out = bufio.NewWriter(&b)
@@ -819,7 +827,7 @@ func TestOutput_printEvents(t *testing.T) { //nolint:golint,paralleltest
 				componentSize: tt.fields.componentSize,
 				propertySize:  tt.fields.propertySize,
 			}
-			if err := o.printEvents(tt.args.out, tt.args.in, tt.args.evdefs, tt.args.typedefs); (err != nil) != tt.wantErr {
+			if err := o.printEvents(tt.args.out, tt.args.in, tt.args.evdefs, tt.args.typedefs, &eventsTable); (err != nil) != tt.wantErr {
 				t.Errorf("Output.printEvents() %s error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			}
 			tt.args.out.Flush()
@@ -952,6 +960,10 @@ func TestOutput_print(t *testing.T) { //nolint:golint,paralleltest
 		{"statEnd", fields{}, args{eventFile: &s10}, line1, false},
 		{"statBegin", fields{}, args{eventFile: &s10, statBegin: true}, line2, false},
 	}
+	eventsTable := EventsTable{
+		Events:     []EventRecord{},
+		Statistics: []EventRecordStatistic{},
+	}
 	for _, tt := range tests { //nolint:golint,paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.out = bufio.NewWriter(&b)
@@ -963,7 +975,7 @@ func TestOutput_print(t *testing.T) { //nolint:golint,paralleltest
 				componentSize: tt.fields.componentSize,
 				propertySize:  tt.fields.propertySize,
 			}
-			if err := o.print(tt.args.out, tt.args.eventFile, tt.args.evdefs, tt.args.typedefs, tt.args.statBegin, tt.args.showStatistic); (err != nil) != tt.wantErr {
+			if err := o.print(tt.args.out, tt.args.eventFile, tt.args.evdefs, tt.args.typedefs, tt.args.statBegin, tt.args.showStatistic, &eventsTable); (err != nil) != tt.wantErr {
 				t.Errorf("Output.print() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			tt.args.out.Flush()
@@ -1006,6 +1018,7 @@ func TestPrint(t *testing.T) { //nolint:golint,paralleltest
 		statBegin     bool
 		showStatistic bool
 	}
+	formatType := "txt"
 	tests := []struct {
 		name    string
 		args    args
@@ -1017,7 +1030,7 @@ func TestPrint(t *testing.T) { //nolint:golint,paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			TimeFactor = nil
 			defer os.Remove(*tt.args.filename)
-			if err := Print(tt.args.filename, tt.args.eventFile, tt.args.evdefs, tt.args.typedefs, tt.args.statBegin, tt.args.showStatistic); (err != nil) != tt.wantErr {
+			if err := Print(tt.args.filename, &formatType, tt.args.eventFile, tt.args.evdefs, tt.args.typedefs, tt.args.statBegin, tt.args.showStatistic); (err != nil) != tt.wantErr {
 				t.Errorf("Print() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			file, err := os.Open(*tt.args.filename)

--- a/tools/eventlist/pkg/output/output_test.go
+++ b/tools/eventlist/pkg/output/output_test.go
@@ -1064,3 +1064,123 @@ func TestPrint(t *testing.T) { //nolint:golint,paralleltest
 		})
 	}
 }
+
+func TestPrintJSON(t *testing.T) { //nolint:golint,paralleltest
+	o1 := "testOutput.json"
+
+	var s10 = "../../testdata/test10.binary"
+
+	lines1 := [...]string{
+		"{\"events\":[{\"index\":0,\"time\":7.75,\"component\":\"0xFF     \",\"eventProperty\":\"0xFF03        \",\"value\":\"val1=0x00000004, val2=0x00000002\"},{\"index\":1,\"time\":7.75,\"component\":\"0xFE     \",\"eventProperty\":\"0xFE00        \",\"value\":\"hello wo\"}],\"statistics\":[]}",
+	}
+
+	type args struct {
+		filename      *string
+		eventFile     *string
+		evdefs        map[uint16]scvd.Event
+		typedefs      map[string]map[string]map[int16]string
+		statBegin     bool
+		showStatistic bool
+	}
+	formatType := "json"
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"test", args{filename: &o1, eventFile: &s10}, false},
+	}
+	for _, tt := range tests { //nolint:golint,paralleltest
+		t.Run(tt.name, func(t *testing.T) {
+			TimeFactor = nil
+			defer os.Remove(*tt.args.filename)
+			if err := Print(tt.args.filename, &formatType, tt.args.eventFile, tt.args.evdefs, tt.args.typedefs, tt.args.statBegin, tt.args.showStatistic); (err != nil) != tt.wantErr {
+				t.Errorf("Print() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			file, err := os.Open(*tt.args.filename)
+			if err != nil {
+				t.Errorf("Print() error = %v, output file not created", err)
+			}
+			if file != nil {
+				in := bufio.NewReader(file)
+				var l string
+				end := false
+				for _, l = range lines1 {
+					line, _ := in.ReadString('\n')
+					if line != l {
+						t.Errorf("Print() %s = %v, want %v", tt.name, line, l)
+					}
+				}
+				line, err := in.ReadString('\n')
+				if errors.Is(err, io.EOF) {
+					end = true
+				} else {
+					t.Errorf("Print() %s = %v, want EOF", tt.name, line)
+				}
+				if !end {
+					t.Errorf("Print() %s = EOF, want %v", tt.name, l)
+				}
+			}
+		})
+	}
+}
+
+func TestPrintXML(t *testing.T) { //nolint:golint,paralleltest
+	o1 := "testOutput.xml"
+
+	var s10 = "../../testdata/test10.binary"
+
+	lines1 := [...]string{
+		"<EventsTable><events><index>0</index><time>7.75</time><component>0xFF     </component><eventProperty>0xFF03        </eventProperty><value>val1=0x00000004, val2=0x00000002</value></events><events><index>1</index><time>7.75</time><component>0xFE     </component><eventProperty>0xFE00        </eventProperty><value>hello wo</value></events></EventsTable>",
+	}
+
+	type args struct {
+		filename      *string
+		eventFile     *string
+		evdefs        map[uint16]scvd.Event
+		typedefs      map[string]map[string]map[int16]string
+		statBegin     bool
+		showStatistic bool
+	}
+	formatType := "xml"
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"test", args{filename: &o1, eventFile: &s10}, false},
+	}
+	for _, tt := range tests { //nolint:golint,paralleltest
+		t.Run(tt.name, func(t *testing.T) {
+			TimeFactor = nil
+			defer os.Remove(*tt.args.filename)
+			if err := Print(tt.args.filename, &formatType, tt.args.eventFile, tt.args.evdefs, tt.args.typedefs, tt.args.statBegin, tt.args.showStatistic); (err != nil) != tt.wantErr {
+				t.Errorf("Print() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			file, err := os.Open(*tt.args.filename)
+			if err != nil {
+				t.Errorf("Print() error = %v, output file not created", err)
+			}
+			if file != nil {
+				in := bufio.NewReader(file)
+				var l string
+				end := false
+				for _, l = range lines1 {
+					line, _ := in.ReadString('\n')
+					if line != l {
+						t.Errorf("Print() %s = %v, want %v", tt.name, line, l)
+					}
+				}
+				line, err := in.ReadString('\n')
+				if errors.Is(err, io.EOF) {
+					end = true
+				} else {
+					t.Errorf("Print() %s = %v, want EOF", tt.name, line)
+				}
+				if !end {
+					t.Errorf("Print() %s = EOF, want %v", tt.name, l)
+				}
+			}
+		})
+	}
+}

--- a/tools/eventlist/pkg/output/output_test.go
+++ b/tools/eventlist/pkg/output/output_test.go
@@ -1071,7 +1071,7 @@ func TestPrintJSON(t *testing.T) { //nolint:golint,paralleltest
 	var s10 = "../../testdata/test10.binary"
 
 	lines1 := [...]string{
-		"{\"events\":[{\"index\":0,\"time\":7.75,\"component\":\"0xFF     \",\"eventProperty\":\"0xFF03        \",\"value\":\"val1=0x00000004, val2=0x00000002\"},{\"index\":1,\"time\":7.75,\"component\":\"0xFE     \",\"eventProperty\":\"0xFE00        \",\"value\":\"hello wo\"}],\"statistics\":[]}",
+		"{\"events\":[{\"index\":0,\"time\":7.75,\"component\":\"0xFF\",\"eventProperty\":\"0xFF03\",\"value\":\"val1=0x00000004, val2=0x00000002\"},{\"index\":1,\"time\":7.75,\"component\":\"0xFE\",\"eventProperty\":\"0xFE00\",\"value\":\"hello wo\"}],\"statistics\":[]}",
 	}
 
 	type args struct {
@@ -1131,7 +1131,7 @@ func TestPrintXML(t *testing.T) { //nolint:golint,paralleltest
 	var s10 = "../../testdata/test10.binary"
 
 	lines1 := [...]string{
-		"<EventsTable><events><index>0</index><time>7.75</time><component>0xFF     </component><eventProperty>0xFF03        </eventProperty><value>val1=0x00000004, val2=0x00000002</value></events><events><index>1</index><time>7.75</time><component>0xFE     </component><eventProperty>0xFE00        </eventProperty><value>hello wo</value></events></EventsTable>",
+		"<EventsTable><events><index>0</index><time>7.75</time><component>0xFF</component><eventProperty>0xFF03</eventProperty><value>val1=0x00000004, val2=0x00000002</value></events><events><index>1</index><time>7.75</time><component>0xFE</component><eventProperty>0xFE00</eventProperty><value>hello wo</value></events></EventsTable>",
 	}
 
 	type args struct {


### PR DESCRIPTION
## Why
It is very difficult to parse existing `txt` output. Addition of `xml` and `json` will allow the output to be easily parsable by other tools/extensions.

## Changes
- Add `xml` and `json` option to format output
It will print events and event statistics as xml/json file or on stdout.

## Example:
 ```
eventlist -f json -o output.json <logFile>
```