### PR TITLE
Update Fault example for AVH Cortex-M7

### DIFF
--- a/Examples/Fault/VHT_MPS2_Cortex-M7/ARM_FaultTrigger.h
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/ARM_FaultTrigger.h
@@ -19,13 +19,12 @@
 #include <stdint.h>
 
 // Fault IDs for fault triggering
-#define ARM_FAULT_ID_HARD_ESCALATED                    (1U)
+#define ARM_FAULT_ID_MEM_DATA                          (1U)
 #define ARM_FAULT_ID_BUS_DATA_PRECISE                  (2U)
 #define ARM_FAULT_ID_BUS_DATA_IMPRECISE                (3U)
 #define ARM_FAULT_ID_BUS_INSTRUCTION                   (4U)
-#define ARM_FAULT_ID_USG_NO_COPROCESSOR                (5U)
-#define ARM_FAULT_ID_USG_UNDEFINED_INSTRUCTION         (6U)
-#define ARM_FAULT_ID_USG_DIV_0                         (7U)
+#define ARM_FAULT_ID_USG_UNDEFINED_INSTRUCTION         (5U)
+#define ARM_FAULT_ID_USG_DIV_0                         (6U)
 
 // ARM_FaultTrigger function ---------------------------------------------------
 

--- a/Examples/Fault/VHT_MPS2_Cortex-M7/Fault.c
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/Fault.c
@@ -51,13 +51,12 @@ static __NO_RETURN void FaultTriggerThread (void *argument) {
   printf("\r\n--- Fault example ---\r\n\r\n");
   printf("To trigger a fault please input a corresponding number:\r\n");
   printf(" - 0: terminate the example\r\n");
-  printf(" - 1: trigger the escalated hard fault\r\n");
-  printf(" - 2: trigger the data access (precise) bus fault\r\n");
-  printf(" - 3: trigger the data access (imprecise) bus fault\r\n");
-  printf(" - 4: trigger the instruction execution bus fault\r\n");
-  printf(" - 5: trigger the no coprocessor usage fault\r\n");
-  printf(" - 6: trigger the undefined instruction usage fault\r\n");
-  printf(" - 7: trigger the divide by 0 usage fault\r\n\r\n");
+  printf(" - 1: data access (precise) Memory Management fault\r\n");
+  printf(" - 2: data access (precise) Bus fault\r\n");
+  printf(" - 3: data access (imprecise) Bus fault\r\n");
+  printf(" - 4: instruction execution Bus fault\r\n");
+  printf(" - 5: undefined instruction Usage fault\r\n");
+  printf(" - 6: divide by 0 Usage fault\r\n\r\n");
   printf("Input>");
 
   for (;;) {
@@ -77,16 +76,36 @@ int main (void) {
 
   SystemCoreClockUpdate();                      // Update SystemCoreClock variable
 
+  SCB->SHCSR |= SCB_SHCSR_BUSFAULTENA_Msk |     // Enable BusFault
+                SCB_SHCSR_USGFAULTENA_Msk;      // Enable UsageFault
+  SCB->CCR   |= SCB_CCR_DIV_0_TRP_Msk;          // Enable divide by 0 trap
+
+  /* Configure MPU
+       - region 0: ROM                   - 0x00000000 .. 0x1FFFFFFF (end is extended to be able to trigger Bus fault)
+       - region 1: RAM                   - 0x20000000 .. 0x3FFFFFFF (end is extended to be able to trigger Bus fault)
+       - region 2: RAM (privileged only) - 0x20000000 .. 0x200000FF
+       - region 3: Peripherals           - 0x40000000 .. 0x4FFFFFFF
+  */
+  ARM_MPU_Disable();
+
+  ARM_MPU_SetRegion(ARM_MPU_RBAR(0U, 0x00000000), ARM_MPU_RASR_EX(0U, ARM_MPU_AP_RO,   ARM_MPU_ACCESS_NORMAL(ARM_MPU_CACHEP_NOCACHE, ARM_MPU_CACHEP_NOCACHE, 0U), 0x00U, ARM_MPU_REGION_SIZE_512MB));
+  ARM_MPU_SetRegion(ARM_MPU_RBAR(1U, 0x20000000), ARM_MPU_RASR_EX(1U, ARM_MPU_AP_FULL, ARM_MPU_ACCESS_NORMAL(ARM_MPU_CACHEP_NOCACHE, ARM_MPU_CACHEP_NOCACHE, 0U), 0x00U, ARM_MPU_REGION_SIZE_512MB));
+  ARM_MPU_SetRegion(ARM_MPU_RBAR(2U, 0x20000000), ARM_MPU_RASR_EX(1U, ARM_MPU_AP_PRIV, ARM_MPU_ACCESS_NORMAL(ARM_MPU_CACHEP_NOCACHE, ARM_MPU_CACHEP_NOCACHE, 0U), 0x00U, ARM_MPU_REGION_SIZE_256B));
+  ARM_MPU_SetRegion(ARM_MPU_RBAR(3U, 0x40000000), ARM_MPU_RASR_EX(1U, ARM_MPU_AP_FULL, ARM_MPU_ACCESS_DEVICE(0U)                                                , 0x00U, ARM_MPU_REGION_SIZE_256MB));
+
+  ARM_MPU_Enable(MPU_CTRL_PRIVDEFENA_Msk);      // Enable Privileged Default
+
   stdio_init();                                 // Initialize STDIO
+
   if (ARM_FaultOccurred() != 0U) {              // If fault information exists
     printf("\r\n\r\n- System Restarted -\r\n\r\n");
   }
 
-  EventRecorderInitialize(EventRecordAll, 1U);  // Initialize and start EventRecorder
+  EventRecorderInitialize(EventRecordAll, 1U);  // Initialize and start Event Recorder
 
   if (ARM_FaultOccurred() != 0U) {              // If fault information exists
-    ARM_FaultRecord();                          // Output decoded fault information via EventRecorder
-    EventRecorderStop();                        // Stop EventRecorder
+    ARM_FaultRecord();                          // Output decoded fault information via Event Recorder
+    EventRecorderStop();                        // Stop Event Recorder
   } else {                                      // If fault information does not exist
     ARM_FaultClear();                           // Clear (initialize) fault information
   }

--- a/Examples/Fault/VHT_MPS2_Cortex-M7/README.md
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/README.md
@@ -51,7 +51,7 @@ Execute the following steps:
    ```
    VHT_MPS2_Cortex-M7 -f vht_config.txt out/Fault/VHT_MPS2_Cortex-M7/Debug/Fault.axf
    ```
-   >Note: The Arm Virtual Hardware executables have to be in the environment path, otherwise absolute path to the 
+   >Note: The Arm Virtual Hardware executables have to be in the environment path, otherwise absolute path to the
           `VHT_MPS2_Cortex-M7.exe` (e.g. c:\Keil\ARM\VHT\VHT_MPS2_Cortex-M7) has to be provided instead of `VHT_MPS2_Cortex-M7`.
 
    The generated file `EventRecorder.log` contains the events that were generated during the example execution.
@@ -62,13 +62,12 @@ Execute the following steps:
 The fault triggering is done by entering a number via simulator console (see possible values below).
 
   - 0: terminate the example
-  - 1: trigger the escalated hard fault
-  - 2: trigger the data access (precise) bus fault
-  - 3: trigger the data access (imprecise) bus fault
-  - 4: trigger the instruction execution bus fault
-  - 5: trigger the no coprocessor usage fault
-  - 6: trigger the undefined instruction usage fault
-  - 7: trigger the divide by 0 usage fault
+  - 1: trigger the data access (precise) Memory Management fault
+  - 2: trigger the data access (precise) Bus fault
+  - 3: trigger the data access (imprecise) Bus fault
+  - 4: trigger the instruction execution Bus fault
+  - 5: trigger the undefined instruction Usage fault
+  - 6: trigger the divide by 0 Usage fault
 
 ### Running the example in the uVision
 

--- a/Examples/Fault/VHT_MPS2_Cortex-M7/RTE/CMSIS/RTX_Config.h
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/RTE/CMSIS/RTX_Config.h
@@ -161,7 +161,7 @@
 //     <1=> Privileged mode
 //   <i> Default: Privileged mode
 #ifndef OS_PRIVILEGE_MODE
-#define OS_PRIVILEGE_MODE           1
+#define OS_PRIVILEGE_MODE           0
 #endif
  
 // </h>

--- a/Examples/Fault/VHT_MPS2_Cortex-M7/RTE/Device/CMSDK_CM7_SP_VHT/ac6_arm.sct
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/RTE/Device/CMSDK_CM7_SP_VHT/ac6_arm.sct
@@ -58,7 +58,7 @@
 #define __RO_SIZE           __ROM_SIZE
 
 #define __RW_BASE           __RAM_BASE
-#define __RW_SIZE          (__RAM_SIZE - __STACK_SIZE - __HEAP_SIZE - __NOINIT_SIZE)
+#define __RW_SIZE          (__RAM_SIZE - 0x100 - __STACK_SIZE - __HEAP_SIZE - __NOINIT_SIZE)
 #define __RW_NOINIT_BASE   (__RAM_BASE + __RW_SIZE)
 
 
@@ -70,7 +70,10 @@ LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
    .ANY (+XO)
   }
 
-  RW_RAM __RW_BASE __RW_SIZE  {                     ; RW data
+  RW_RAM_PRIV __RW_BASE EMPTY 0x100 {               ; RAM only accessible by privileged code (MPU)
+  }
+
+  RW_RAM (__RW_BASE + 0x100) __RW_SIZE  {           ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/Examples/Fault/VHT_MPS2_Cortex-M7/retarget_stdio.c
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/retarget_stdio.c
@@ -32,25 +32,25 @@ extern int stdin_getchar  (void);
 
 #define _USART_Driver_(n)  Driver_USART##n
 #define  USART_Driver_(n) _USART_Driver_(n)
- 
+
 extern ARM_DRIVER_USART  USART_Driver_(USART_DRV_NUM);
 #define ptrUSART       (&USART_Driver_(USART_DRV_NUM))
 
 /**
   Initialize stdio
- 
+
   \return          0 on success, or -1 on error.
 */
 int stdio_init (void) {
- 
+
   if (ptrUSART->Initialize(NULL) != ARM_DRIVER_OK) {
     return -1;
   }
- 
+
   if (ptrUSART->PowerControl(ARM_POWER_FULL) != ARM_DRIVER_OK) {
     return -1;
   }
- 
+
   if (ptrUSART->Control(ARM_USART_MODE_ASYNCHRONOUS |
                         ARM_USART_DATA_BITS_8       |
                         ARM_USART_PARITY_NONE       |
@@ -59,23 +59,23 @@ int stdio_init (void) {
                         USART_BAUDRATE) != ARM_DRIVER_OK) {
     return -1;
   }
- 
+
   if (ptrUSART->Control(ARM_USART_CONTROL_RX, 1U) != ARM_DRIVER_OK) {
     return -1;
   }
- 
+
   return 0;
 }
 
 /**
   Put a character to the stderr
- 
+
   \param[in]   ch  Character to output
   \return          The character written, or -1 on error.
 */
 int stderr_putchar (int ch) {
   uint8_t buf[1];
- 
+
   buf[0] = (uint8_t)ch;
 
   if (ptrUSART->Send(buf, 1U) != ARM_DRIVER_OK) {
@@ -95,7 +95,7 @@ int stderr_putchar (int ch) {
 */
 int stdout_putchar (int ch) {
   uint8_t buf[1];
- 
+
   buf[0] = (uint8_t)ch;
 
   if (ptrUSART->Send(buf, 1U) != ARM_DRIVER_OK) {
@@ -109,12 +109,12 @@ int stdout_putchar (int ch) {
 
 /**
   Get a character from the stdio
- 
+
   \return     The next character from the input, or -1 on error.
 */
 int stdin_getchar (void) {
   uint8_t buf[1];
- 
+
   if (ptrUSART->Receive(buf, 1U) != ARM_DRIVER_OK) {
     return -1;
   }


### PR DESCRIPTION
- add Memory Management fault triggering
- change threads to run in non-privileged mode
- minor cleanup (trailing spaces removed)