### PR TITLE
Minor Fault update (improved GCC support)

### DIFF
--- a/Doxygen/src/EventRecorder.md
+++ b/Doxygen/src/EventRecorder.md
@@ -265,7 +265,7 @@ for the **Arm Compiler** toolchain add the following code snippet to the linker 
 
   ```
   RW_NOINIT <start_address> UNINIT 0x800 {
-    * (.bss.noinit)
+    * (.bss.noinit*)
   }
   ```
 
@@ -282,7 +282,7 @@ for the **GCC** toolchain add the following code snippet to the linker script (.
   {
     . = ALIGN(4);
     PROVIDE (__noinit_start = .);
-    *(.noinit)
+    *(.noinit*)
     . = ALIGN(4);
     PROVIDE (__noinit_end = .);
   } > RAM

--- a/Doxygen/src/Fault.md
+++ b/Doxygen/src/Fault.md
@@ -129,7 +129,7 @@ for the **Arm Compiler** toolchain add the following code snippet to the linker 
 
   ```
   RW_NOINIT <start_address> UNINIT 0x800 {
-    * (.bss.noinit)
+    * (.bss.noinit*)
   }
   ```
 
@@ -146,7 +146,7 @@ for the **GCC** toolchain add the following code snippet to the linker script (.
   {
     . = ALIGN(4);
     PROVIDE (__noinit_start = .);
-    *(.noinit)
+    *(.noinit*)
     . = ALIGN(4);
     PROVIDE (__noinit_end = .);
   } > RAM

--- a/Fault/Source/ARM_FaultStorage.c
+++ b/Fault/Source/ARM_FaultStorage.c
@@ -38,13 +38,13 @@
 #if !defined(__NO_INIT)
   //lint -esym(9071, __NO_INIT) "Suppress: defined macro is reserved to the compiler"
   #if   defined (__CC_ARM)                                           /* ARM Compiler 4/5 */
-    #define __NO_INIT __attribute__ ((section (".bss.noinit"), zero_init))
+    #define __NO_INIT __attribute__ ((section (".bss.noinit.fault"), zero_init))
   #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)    /* ARM Compiler 6 */
-    #define __NO_INIT __attribute__ ((section (".bss.noinit")))
+    #define __NO_INIT __attribute__ ((section (".bss.noinit.fault")))
   #elif defined (__GNUC__)                                           /* GNU Compiler */
-    #define __NO_INIT __attribute__ ((section (".noinit")))
+    #define __NO_INIT __attribute__ ((section (".noinit.fault")))
   #elif defined (__ICCARM__)                                         /* IAR Compiler */
-    #define __NO_INIT __attribute__ ((section (".noinit")))
+    #define __NO_INIT __attribute__ ((section (".noinit.fault")))
   #else
     #warning "No compiler specific solution for __NO_INIT. __NO_INIT is ignored."
     #define __NO_INIT
@@ -425,7 +425,7 @@ __NAKED void ARM_FaultSave (void) {
 #endif
 #endif
  :  /* clobber list */
-    "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "cc", "memory");
+    "r0", "r1", "r2", "r3", "cc", "memory");
 
 #if (ARM_FAULT_FAULT_REGS_EXIST != 0)       // If fault registers exist
   __ASM volatile (
@@ -518,7 +518,7 @@ __NAKED void ARM_FaultSave (void) {
 #endif
 #endif
  :  /* clobber list */
-    "r0", "r1", "r2", "r3", "r5", "r6", "cc", "memory");
+    "r0", "r1", "r2", "r3", "cc", "memory");
 #endif
 
   __ASM volatile (
@@ -602,7 +602,7 @@ __NAKED void ARM_FaultSave (void) {
  ,  [crc_data_len]                          "i" (sizeof(ARM_FaultInfo) - (sizeof(ARM_FaultInfo.MagicNumber) + sizeof(ARM_FaultInfo.CRC32)))
  ,  [crc_polynom]                           "i" (ARM_FAULT_CRC32_POLYNOM)
  :  /* clobber list */
-    "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "cc", "memory");
+    "r0", "r1", "r2", "r3", "cc", "memory");
 }
 
 /**


### PR DESCRIPTION
- extend section name for fault information for easier absolute addressing via the linker script
- update documentation regarding section name change
- update ARM_FaultSave function (removed registers R4 .. R7 from clobber list because complete function does not change values of R4 .. R7 registers)