### PR TITLE
Minor update to ARM_FaultPrint function (improved GCC support)

### DIFF
--- a/Fault/Template/ARM_FaultPrint.c
+++ b/Fault/Template/ARM_FaultPrint.c
@@ -76,7 +76,7 @@ void ARM_FaultPrint (void) {
   }
 
   // Output: Fault count
-  printf("  Fault count:         %u\n\n", ARM_FaultInfo.Count);
+  printf("  Fault count:         %u\n\n", (unsigned int)ARM_FaultInfo.Count);
 
   // Output: Exception which saved the fault information
   printf("  Exception Handler:   ");
@@ -106,7 +106,7 @@ void ARM_FaultPrint (void) {
       printf("SecureFault");
       break;
     default:
-      printf("unknown, exception number = %u", (uint32_t)(ARM_FaultInfo.ExceptionState.xPSR & IPSR_ISR_Msk));
+      printf("unknown, exception number = %u", (unsigned int)(ARM_FaultInfo.ExceptionState.xPSR & IPSR_ISR_Msk));
       break;
   }
   printf("\n");
@@ -192,7 +192,7 @@ void ARM_FaultPrint (void) {
       }
 #endif
       if ((scb_cfsr & SCB_CFSR_MMARVALID_Msk) != 0U) {
-        printf(", fault address 0x%08X", scb_mmfar);
+        printf(", fault address 0x%08X", (unsigned int)scb_mmfar);
       }
       printf("\n");
     }
@@ -235,7 +235,7 @@ void ARM_FaultPrint (void) {
       }
 #endif
       if ((scb_cfsr & SCB_CFSR_BFARVALID_Msk) != 0U) {
-        printf(", fault address 0x%08X", scb_bfar);
+        printf(", fault address 0x%08X", (unsigned int)scb_bfar);
       }
       printf("\n");
     }
@@ -322,7 +322,7 @@ void ARM_FaultPrint (void) {
         printf("Lazy stacking activation or deactivation failure");
       }
       if ((scb_sfsr & SAU_SFSR_SFARVALID_Msk) != 0U) {
-        printf(", fault address 0x%08X", scb_sfar);
+        printf(", fault address 0x%08X", (unsigned int)scb_sfar);
       }
       printf("\n");
     }
@@ -337,7 +337,7 @@ void ARM_FaultPrint (void) {
   printf("  Program Counter:     ");
 
   if (ARM_FaultInfo.Content.StateContext != 0U) {
-    printf("0x%08X\n", ARM_FaultInfo.Registers.ReturnAddress);
+    printf("0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.ReturnAddress);
   } else {
     printf("unknown (was not stacked)\n");
   }
@@ -347,29 +347,29 @@ void ARM_FaultPrint (void) {
      was stacked) or values as they were when fault handler started execution */
   printf("\n  Registers:\n");
   if (ARM_FaultInfo.Content.StateContext != 0U) {
-    printf("   - R0:               0x%08X\n", ARM_FaultInfo.Registers.R0);
-    printf("   - R1:               0x%08X\n", ARM_FaultInfo.Registers.R1);
-    printf("   - R2:               0x%08X\n", ARM_FaultInfo.Registers.R2);
-    printf("   - R3:               0x%08X\n", ARM_FaultInfo.Registers.R3);
+    printf("   - R0:               0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.R0);
+    printf("   - R1:               0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.R1);
+    printf("   - R2:               0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.R2);
+    printf("   - R3:               0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.R3);
   } else {
     printf("   - R0 .. R3:         unknown (were not stacked)\n");
   }
 
   /* Output: R4 .. R11 */
-  printf("   - R4:               0x%08X\n", ARM_FaultInfo.Registers.R4);
-  printf("   - R5:               0x%08X\n", ARM_FaultInfo.Registers.R5);
-  printf("   - R6:               0x%08X\n", ARM_FaultInfo.Registers.R6);
-  printf("   - R7:               0x%08X\n", ARM_FaultInfo.Registers.R7);
-  printf("   - R8:               0x%08X\n", ARM_FaultInfo.Registers.R8);
-  printf("   - R9:               0x%08X\n", ARM_FaultInfo.Registers.R9);
-  printf("   - R10:              0x%08X\n", ARM_FaultInfo.Registers.R10);
-  printf("   - R11:              0x%08X\n", ARM_FaultInfo.Registers.R11);
+  printf("   - R4:               0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.R4);
+  printf("   - R5:               0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.R5);
+  printf("   - R6:               0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.R6);
+  printf("   - R7:               0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.R7);
+  printf("   - R8:               0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.R8);
+  printf("   - R9:               0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.R9);
+  printf("   - R10:              0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.R10);
+  printf("   - R11:              0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.R11);
 
   if (ARM_FaultInfo.Content.StateContext != 0U) {
-    printf("   - R12:              0x%08X\n",   ARM_FaultInfo.Registers.R12);
-    printf("   - LR:               0x%08X\n",   ARM_FaultInfo.Registers.LR);
-    printf("   - Return Address:   0x%08X\n",   ARM_FaultInfo.Registers.ReturnAddress);
-    printf("   - xPSR:             0x%08X\n\n", ARM_FaultInfo.Registers.xPSR);
+    printf("   - R12:              0x%08X\n",   (unsigned int)ARM_FaultInfo.Registers.R12);
+    printf("   - LR:               0x%08X\n",   (unsigned int)ARM_FaultInfo.Registers.LR);
+    printf("   - Return Address:   0x%08X\n",   (unsigned int)ARM_FaultInfo.Registers.ReturnAddress);
+    printf("   - xPSR:             0x%08X\n\n", (unsigned int)ARM_FaultInfo.Registers.xPSR);
   } else {
     printf("   - R12:              unknown (was not stacked)\n");
     printf("   - LR:               unknown (was not stacked)\n");
@@ -377,19 +377,19 @@ void ARM_FaultPrint (void) {
     printf("   - xPSR:             unknown (was not stacked)\n");
   }
 
-  printf("   - MSP:              0x%08X\n", ARM_FaultInfo.Registers.MSP);
+  printf("   - MSP:              0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.MSP);
   if (ARM_FaultInfo.Content.LimitRegs != 0U) {
-    printf("   - MSPLIM:           0x%08X\n", ARM_FaultInfo.Registers.MSPLIM);
+    printf("   - MSPLIM:           0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.MSPLIM);
   }
-  printf("   - PSP:              0x%08X\n", ARM_FaultInfo.Registers.PSP);
+  printf("   - PSP:              0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.PSP);
   if (ARM_FaultInfo.Content.LimitRegs != 0U) {
-    printf("   - PSPLIM:           0x%08X\n", ARM_FaultInfo.Registers.PSPLIM);
+    printf("   - PSPLIM:           0x%08X\n", (unsigned int)ARM_FaultInfo.Registers.PSPLIM);
   }
 
   /* Output: Exception State */
   printf("\n  Exception State:\n");
-  printf("   - xPSR:             0x%08X\n", ARM_FaultInfo.ExceptionState.xPSR);
-  printf("   - Exception Return: 0x%08X\n", ARM_FaultInfo.ExceptionState.EXC_RETURN);
+  printf("   - xPSR:             0x%08X\n", (unsigned int)ARM_FaultInfo.ExceptionState.xPSR);
+  printf("   - Exception Return: 0x%08X\n", (unsigned int)ARM_FaultInfo.ExceptionState.EXC_RETURN);
   printf("\n");
 
 #if (ARM_FAULT_FAULT_REGS_EXIST != 0)
@@ -397,21 +397,21 @@ void ARM_FaultPrint (void) {
   if (ARM_FaultInfo.Content.FaultRegs != 0U) {
     printf("  Fault Registers:\n");
 
-    printf("   - CFSR:             0x%08X\n", ARM_FaultInfo.FaultRegisters.CFSR);
-    printf("   - HFSR:             0x%08X\n", ARM_FaultInfo.FaultRegisters.HFSR);
-    printf("   - DFSR:             0x%08X\n", ARM_FaultInfo.FaultRegisters.DFSR);
-    printf("   - MMFAR:            0x%08X\n", ARM_FaultInfo.FaultRegisters.MMFAR);
-    printf("   - BFAR:             0x%08X\n", ARM_FaultInfo.FaultRegisters.BFAR);
-    printf("   - AFSR:             0x%08X\n", ARM_FaultInfo.FaultRegisters.AFSR);
+    printf("   - CFSR:             0x%08X\n", (unsigned int)ARM_FaultInfo.FaultRegisters.CFSR);
+    printf("   - HFSR:             0x%08X\n", (unsigned int)ARM_FaultInfo.FaultRegisters.HFSR);
+    printf("   - DFSR:             0x%08X\n", (unsigned int)ARM_FaultInfo.FaultRegisters.DFSR);
+    printf("   - MMFAR:            0x%08X\n", (unsigned int)ARM_FaultInfo.FaultRegisters.MMFAR);
+    printf("   - BFAR:             0x%08X\n", (unsigned int)ARM_FaultInfo.FaultRegisters.BFAR);
+    printf("   - AFSR:             0x%08X\n", (unsigned int)ARM_FaultInfo.FaultRegisters.AFSR);
 
     if (ARM_FaultInfo.Content.SecureFaultRegs != 0U) {
-      printf("   - SFSR:             0x%08X\n", ARM_FaultInfo.FaultRegisters.SFSR);
-      printf("   - SFAR:             0x%08X\n", ARM_FaultInfo.FaultRegisters.SFAR);
+      printf("   - SFSR:             0x%08X\n", (unsigned int)ARM_FaultInfo.FaultRegisters.SFSR);
+      printf("   - SFAR:             0x%08X\n", (unsigned int)ARM_FaultInfo.FaultRegisters.SFAR);
     }
 
 #if (ARM_FAULT_ARCH_ARMV8_1M_MAIN != 0)
     if (ARM_FaultInfo.Content.RAS_FaultReg != 0U) {
-      printf("   - RFSR:             0x%08X\n", ARM_FaultInfo.FaultRegisters.RFSR);
+      printf("   - RFSR:             0x%08X\n", (unsigned int)ARM_FaultInfo.FaultRegisters.RFSR);
     }
 #endif
 


### PR DESCRIPTION
- remove warning: format '%u' expects argument of type 'unsigned int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'}