### PR TITLE
Update Fault example for AVH Cortex-M7

### DIFF
--- a/Examples/Fault/VHT_MPS2_Cortex-M7/Fault.cproject.yml
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/Fault.cproject.yml
@@ -13,7 +13,8 @@ project:
   groups:
     - group: Documentation
       files:
-        - file: ./README.md
+        - file: README.md
+
     - group: Source Files
       files:
         - file: Fault.c
@@ -21,19 +22,19 @@ project:
         - file: retarget_stdio.c
 
   components:
-    - component: ARM::CMSIS:CORE
-    - component: ARM::CMSIS:RTOS2:Keil RTX5&Source
+    - component: CMSIS:CORE
+    - component: CMSIS:RTOS2:Keil RTX5&Source
 
-    - component: ARM::CMSIS-Compiler:I/O:STDERR&User
-    - component: ARM::CMSIS-Compiler:I/O:STDOUT&User
-    - component: ARM::CMSIS-Compiler:I/O:STDIN&User
+    - component: CMSIS-Compiler:I/O:STDERR&User
+    - component: CMSIS-Compiler:I/O:STDOUT&User
+    - component: CMSIS-Compiler:I/O:STDIN&User
 
-    - component: ARM::CMSIS-View:Event Recorder&Semihosting
-    - component: ARM::CMSIS-View:Fault:Record
-    - component: ARM::CMSIS-View:Fault:Storage
+    - component: CMSIS-View:Event Recorder&Semihosting
+    - component: CMSIS-View:Fault:Record
+    - component: CMSIS-View:Fault:Storage
 
-    - component: Keil::Board Support&V2M-MPS2:Common
+    - component: Board Support&V2M-MPS2:Common
 
-    - component: Keil::CMSIS Driver:USART
+    - component: CMSIS Driver:USART
 
-    - component: Keil::Device:Startup&C Startup
+    - component: Device:Startup&C Startup

--- a/Examples/Fault/VHT_MPS2_Cortex-M7/Fault.csolution.yml
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/Fault.csolution.yml
@@ -14,8 +14,6 @@ solution:
     - type: Debug
       debug: on
       optimize: none
-      define:
-        - DEBUG
 
   projects:
     - project: ./Fault.cproject.yml

--- a/Examples/Fault/VHT_MPS2_Cortex-M7/Fault.csolution.yml
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/Fault.csolution.yml
@@ -13,7 +13,9 @@ solution:
   build-types:
     - type: Debug
       debug: on
-      optimize: balanced
+      optimize: none
+      define:
+        - DEBUG
 
   projects:
     - project: ./Fault.cproject.yml

--- a/Examples/Fault/VHT_MPS2_Cortex-M7/README.md
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/README.md
@@ -13,17 +13,19 @@ The fault information can also be inspected with **Component Viewer** in a debug
 ## Prerequisites
 
 ### Software:
- - [**CMSIS-Toolbox v1.6.0**](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/releases/tag/1.6.0) or newer
+ - [**CMSIS-Toolbox v2.0.0**](https://github.com/Open-CMSIS-Pack/devtools/releases) or newer
  - [**Keil MDK v5.38**](https://www.keil.com/mdk5) or newer containing:
    - Arm Compiler 6 (part of the MDK)
    - Arm Virtual Hardware (AVH) for MPS2 platform with Cortex-M7 (part of the MDK-Professional)
  - [**eventlist v1.1.0**](https://github.com/ARM-software/CMSIS-View/releases/tag/tools%2Feventlist%2F1.1.0) or newer
+ - [**Arm GNU Toolchain v12.2.MPACBTI-Rel1**](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+   (only necessary when building example with GCC)
 
 ### CMSIS Packs:
  - Required packs:
-    - ARM::CMSIS-View v1.0.0 or newer
-    - ARM::CMSIS-Compiler v1.0.0 or newer
-    - ARM::CMSIS v5.9.0
+    - ARM::CMSIS-View
+    - ARM::CMSIS-Compiler
+    - ARM::CMSIS
     - Keil::V2M-MPS2_CMx_BSP v1.8.0
 
    Missing packs can be installed by executing the following `csolution` and `cpackget` commands:
@@ -99,3 +101,6 @@ To process `EventRecorder.log` file with the `eventlist` utility in **Windows Co
    ```
    eventlist -I %CMSIS_PACK_ROOT%\ARM\CMSIS-View\1.0.0\Fault\ARM_Fault.scvd -I %CMSIS_PACK_ROOT%\ARM\CMSIS-View\1.0.0\EventRecorder\EventRecorder.scvd -I %CMSIS_PACK_ROOT%\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd EventRecorder.log
    ```
+
+> Note: If CMSIS-View v1.0.0 or CMSIS v5.9.0 packs are not installed, in the previous command replace corresponding path with the path of the latest installed packs
+        (for example replace "%CMSIS_PACK_ROOT%\ARM\CMSIS-View\1.0.0\Fault\" with "%CMSIS_PACK_ROOT%\ARM\CMSIS-View\1.0.1\Fault\")

--- a/Examples/Fault/VHT_MPS2_Cortex-M7/README.md
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/README.md
@@ -99,8 +99,8 @@ To analyze the result `eventlist` utility is needed, copy the executable `eventl
 
 To process `EventRecorder.log` file with the `eventlist` utility in **Windows Command Prompt** (cmd.exe) execute the following command:
    ```
-   eventlist -I %CMSIS_PACK_ROOT%\ARM\CMSIS-View\1.0.0\Fault\ARM_Fault.scvd -I %CMSIS_PACK_ROOT%\ARM\CMSIS-View\1.0.0\EventRecorder\EventRecorder.scvd -I %CMSIS_PACK_ROOT%\ARM\CMSIS\5.9.0\CMSIS\RTOS2\RTX\RTX5.scvd EventRecorder.log
+   eventlist -I %CMSIS_PACK_ROOT%/ARM/CMSIS-View/1.0.0/Fault/ARM_Fault.scvd -I %CMSIS_PACK_ROOT%/ARM/CMSIS-View/1.0.0/EventRecorder/EventRecorder.scvd -I %CMSIS_PACK_ROOT%/ARM\CMSIS/5.9.0/CMSIS/RTOS2/RTX/RTX5.scvd EventRecorder.log
    ```
 
 > Note: If CMSIS-View v1.0.0 or CMSIS v5.9.0 packs are not installed, in the previous command replace corresponding path with the path of the latest installed packs
-        (for example replace "%CMSIS_PACK_ROOT%\ARM\CMSIS-View\1.0.0\Fault\" with "%CMSIS_PACK_ROOT%\ARM\CMSIS-View\1.0.1\Fault\")
+        (for example replace "%CMSIS_PACK_ROOT%/ARM/CMSIS-View/1.0.0/Fault/" with "%CMSIS_PACK_ROOT%/ARM/CMSIS-View/1.0.1/Fault/")

--- a/Examples/Fault/VHT_MPS2_Cortex-M7/README.md
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/README.md
@@ -13,7 +13,7 @@ The fault information can also be inspected with **Component Viewer** in a debug
 ## Prerequisites
 
 ### Software:
- - [**CMSIS-Toolbox v2.0.0**](https://github.com/Open-CMSIS-Pack/devtools/releases) or newer
+ - [**CMSIS-Toolbox v2.0.0**](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/releases) or newer
  - [**Keil MDK v5.38**](https://www.keil.com/mdk5) or newer containing:
    - Arm Compiler 6 (part of the MDK)
    - Arm Virtual Hardware (AVH) for MPS2 platform with Cortex-M7 (part of the MDK-Professional)

--- a/Examples/Fault/VHT_MPS2_Cortex-M7/cdefault.yml
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/cdefault.yml
@@ -22,4 +22,5 @@ default:
         - -std=gnu11
       Link:
         - --entry=Reset_Handler
+        - --specs=nano.specs
         - -Wl,-Map=$elf()$.map


### PR DESCRIPTION
- for GCC use newlib-nano instead of newlib
- change optimization level from balanced to no optimization (in sync with other example)
- minor update to README.md