### PR TITLE
Minor update to EventStatistic example documentation

### DIFF
--- a/Examples/EventStatistic/README.md
+++ b/Examples/EventStatistic/README.md
@@ -36,7 +36,7 @@ As an alternative the example runs also on [**AMI Arm Virtual Hardware**](https:
 The following commands convert and build the project with build type `Debug` and target type `AVH`:
 
 ```sh
-cbuild EventStatistic.csolution.yml --update-rte -p --configuration .Debug+AVH
+cbuild EventStatistic.csolution.yml --update-rte -p -c .Debug+AVH
 ```
 
 ## Execute


### PR DESCRIPTION
- corrected cbuild command snippet in the README.md to work with CMSIS-Toolbox v2.0.0