### PR TITLE
Update section names for non-initialized variables for AC6

### DIFF
--- a/Documentation/Doxygen/src/event_recorder.md
+++ b/Documentation/Doxygen/src/event_recorder.md
@@ -260,8 +260,8 @@ For the **Arm Compiler** toolchain add the following code snippet to the linker 
 
 ```
   RW_NOINIT <start_address> UNINIT 0x800 {
-    *(.noinit)
-    *(.noinit.*)
+    *(.bss.noinit)
+    *(.bss.noinit.*)
   }
 ```
 

--- a/Documentation/Doxygen/src/fault.md
+++ b/Documentation/Doxygen/src/fault.md
@@ -133,8 +133,8 @@ For the Arm Compiler toolchain add the following code snippet to the linker scri
 
 ```
   RW_NOINIT <start_address> UNINIT 0x800 {
-    *(.noinit)
-    *(.noinit.*)
+    *(.bss.noinit)
+    *(.bss.noinit.*)
   }
 ```
 

--- a/EventRecorder/Source/EventRecorder.c
+++ b/EventRecorder/Source/EventRecorder.c
@@ -41,8 +41,12 @@
 #endif
 
 #if !defined(__NO_INIT)
-//lint -esym(9071, __NO_INIT) "defined macro is reserved to the compiler"
-#define __NO_INIT __attribute__ ((section (".noinit")))
+  //lint -esym(9071, __NO_INIT) "Suppress: defined macro is reserved to the compiler"
+  #if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)         /* ARM Compiler 6 */
+    #define __NO_INIT __attribute__ ((section (".bss.noinit")))
+  #else                                                                 /* all other compilers */
+    #define __NO_INIT __attribute__ ((section (".noinit")))
+  #endif
 #endif
 
 //lint -e(9026) "Function-like macro"

--- a/Examples/EventStatistic/RTE/Device/SSE-300-MPS3/fvp_sse300_mps3_s.sct
+++ b/Examples/EventStatistic/RTE/Device/SSE-300-MPS3/fvp_sse300_mps3_s.sct
@@ -59,8 +59,8 @@ LR_CODE S_CODE_START {
     }
 
     ER_DATA_NOINIT +0 ALIGN 64 UNINIT 0x00002000 {
-        *(.noinit)
-        *(.noinit.*)
+        *(.bss.noinit)
+        *(.bss.noinit.*)
     }
 
     #if HEAP_SIZE > 0

--- a/Examples/Fault/B-U585I-IOT02A/Fault.csolution.yml
+++ b/Examples/Fault/B-U585I-IOT02A/Fault.csolution.yml
@@ -5,7 +5,7 @@ solution:
 
   packs:
     - pack: Keil::STM32U5xx_DFP@2.1.0
-    - pack: Keil::B-U585I-IOT02A_BSP@1.0.0
+    - pack: Keil::B-U585I-IOT02A_BSP
 
   target-types:
     - type: HW

--- a/Examples/Fault/B-U585I-IOT02A/NonSecure/Fault_NS.uvprojx
+++ b/Examples/Fault/B-U585I-IOT02A/NonSecure/Fault_NS.uvprojx
@@ -712,7 +712,7 @@
       </package>
       <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.2" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.0.0">
         <targetInfos>
-          <targetInfo name="B-U585I-IOT02A" versionMatchMode="fixed"/>
+          <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </package>
       <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0">

--- a/Examples/Fault/B-U585I-IOT02A/NonSecure/RTE/Device/STM32U585AIIx/stm32u585xx_flash_ns.sct
+++ b/Examples/Fault/B-U585I-IOT02A/NonSecure/RTE/Device/STM32U585AIIx/stm32u585xx_flash_ns.sct
@@ -99,12 +99,12 @@ LR_APP __LR_BASE __LR_SIZE  {                                        /* load reg
   }
 
   RW_NOINIT_FAULT 0x200B0000 UNINIT 0x100 {                          /* Uninitialized memory for Fault information (ARM_FaultInfo) */
-    *(.noinit.fault)
+    *(.bss.noinit.fault)
   }
 
 #if __NOINIT_SIZE > 0
   RW_NOINIT __RW_NOINIT_BASE UNINIT __NOINIT_SIZE {                  /* no init data */
-    *(.noinit)
+    *(.bss.noinit)
   }
 #endif
 

--- a/Examples/Fault/B-U585I-IOT02A/Secure/Fault_S.uvprojx
+++ b/Examples/Fault/B-U585I-IOT02A/Secure/Fault_S.uvprojx
@@ -687,7 +687,7 @@
       </package>
       <package name="B-U585I-IOT02A_BSP" schemaVersion="1.7.2" url="https://github.com/MDK-Packs/Pack/raw/master/B-U585I-IOT02A_BSP/" vendor="Keil" version="1.0.0">
         <targetInfos>
-          <targetInfo name="B-U585I-IOT02A" versionMatchMode="fixed"/>
+          <targetInfo name="B-U585I-IOT02A"/>
         </targetInfos>
       </package>
       <package name="STM32U5xx_DFP" schemaVersion="1.7.15" url="https://www.keil.com/pack/" vendor="Keil" version="2.1.0">

--- a/Examples/Fault/B-U585I-IOT02A/Secure/RTE/Device/STM32U585AIIx/stm32u585xx_flash_s.sct
+++ b/Examples/Fault/B-U585I-IOT02A/Secure/RTE/Device/STM32U585AIIx/stm32u585xx_flash_s.sct
@@ -109,7 +109,7 @@ LR_APP __LR_BASE __LR_SIZE  {                                        /* load reg
 
 #if __NOINIT_SIZE > 0
   RW_NOINIT __RW_NOINIT_BASE UNINIT __NOINIT_SIZE {                  /* no init data */
-    *(.noinit)
+    *(.bss.noinit)
   }
 #endif
 
@@ -125,7 +125,7 @@ LR_APP __LR_BASE __LR_SIZE  {                                        /* load reg
   }
 
   RW_NS_NOINIT_FAULT 0x200B0000 UNINIT 0x100 {                       /* Uninitialized memory for Fault information (ARM_FaultInfo) */
-    *(.noinit.fault)
+    *(.bss.noinit.fault)
   }
 }
 

--- a/Examples/Fault/VHT_MPS2_Cortex-M7/RTE/Device/CMSDK_CM7_SP_VHT/ac6_arm.sct
+++ b/Examples/Fault/VHT_MPS2_Cortex-M7/RTE/Device/CMSDK_CM7_SP_VHT/ac6_arm.sct
@@ -79,8 +79,8 @@ LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
 
 #if __NOINIT_SIZE > 0
   RW_NOINIT __RW_NOINIT_BASE UNINIT __NOINIT_SIZE { ; no init data
-    *(.noinit)
-    *(.noinit.*)
+    *(.bss.noinit)
+    *(.bss.noinit.*)
   }
 #endif
 

--- a/Fault/Source/ARM_FaultStorage.c
+++ b/Fault/Source/ARM_FaultStorage.c
@@ -28,12 +28,16 @@
 
 // Compiler-specific defines
 #if !defined(__NAKED)
-//lint -esym(9071, __NAKED) "Suppress: defined macro is reserved to the compiler"
-#define __NAKED __attribute__((naked))
+  //lint -esym(9071, __NAKED) "Suppress: defined macro is reserved to the compiler"
+  #define __NAKED __attribute__((naked))
 #endif
-#if !defined(__NO_INIT_FAULT)
-//lint -esym(9071, __NO_INIT_FAULT) "Suppress: defined macro is reserved to the compiler"
-#define __NO_INIT_FAULT __attribute__ ((section (".noinit.fault")))
+#if !defined(__NO_INIT__FAULT)
+  //lint -esym(9071, __NO_INIT_FAULT) "Suppress: defined macro is reserved to the compiler"
+  #if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)         /* ARM Compiler 6 */
+    #define __NO_INIT_FAULT __attribute__ ((section (".bss.noinit.fault")))
+  #else                                                                 /* all other compilers */
+    #define __NO_INIT_FAULT __attribute__ ((section (".noinit.fault")))
+  #endif
 #endif
 
 #if    (ARM_FAULT_FAULT_REGS_EXIST != 0)


### PR DESCRIPTION
- synchronize with latest CMSIS core
- in example for B-U585I-IOT02A board BSP pack set to latest since VIO using new API from CMSIS-6 is incompatible with implementation in BSP v1.0.0