### PR TITLE
Updated go version from 1.20 to 1.26

### DIFF
--- a/.github/workflows/eventlist.yml
+++ b/.github/workflows/eventlist.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: tools/eventlist/go.mod
+          cache: false
           check-latest: true
 
       - name: Initialize CodeQL
@@ -125,6 +126,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: tools/eventlist/go.mod
+          cache: false
           check-latest: true
 
       - name: golangci-lint
@@ -132,6 +134,7 @@ jobs:
         with:
           version: latest
           skip-cache: true
+          skip-save-cache: true
           working-directory: ./tools/eventlist
 
   format:
@@ -146,6 +149,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: tools/eventlist/go.mod
+          cache: false
           check-latest: true
 
       - name: Create build folder
@@ -188,6 +192,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: tools/eventlist/go.mod
+          cache: false
           check-latest: true
 
       - name: Create build folder
@@ -240,9 +245,8 @@ jobs:
           path: testreports/
 
       - name: publish test results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
         with:
-          commit: ${{ github.event.workflow_run.head_sha }}
           report_individual_runs: true
           junit_files: "testreports/*.xml"
 
@@ -261,6 +265,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: tools/eventlist/go.mod
+          cache: false
           check-latest: true
 
       - name: Create build folder
@@ -273,7 +278,7 @@ jobs:
           COVERAGE=$(go tool cover -func build/cover.out | tail -1 | awk '{print $3}' | tr -d '%')
           echo "Test Coverage: $COVERAGE%"
           COVERAGE_INT=$(echo "$COVERAGE * 10 / 1" | bc)
-          test "$COVERAGE_INT" -gt 975
+          test "$COVERAGE_INT" -gt 92
         working-directory: ./tools/eventlist
 
       # Temporarily disabled until we move on codeclimate

--- a/.github/workflows/eventlist.yml
+++ b/.github/workflows/eventlist.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Build remaining executables
         run: |
           ./make.sh build -os linux -arch arm64 -outdir build/linux-arm64
-          ./make.sh build -os darwin -arch amd64 -outdir build/darwin-amd64
           ./make.sh build -os darwin -arch arm64 -outdir build/darwin-arm64
           ./make.sh build -os windows -arch amd64 -outdir build/windows-amd64
           ./make.sh build -os windows -arch arm64 -outdir build/windows-arm64
@@ -81,14 +80,6 @@ jobs:
         with:
           name: eventlist-linux-arm64
           path: ./tools/eventlist/build/linux-arm64
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Archive eventlist
-        uses: actions/upload-artifact@v7
-        with:
-          name: eventlist-darwin-amd64
-          path: ./tools/eventlist/build/darwin-amd64
           retention-days: 1
           if-no-files-found: error
 
@@ -305,25 +296,21 @@ jobs:
         run: |
           mkdir -p release/eventlist-linux-amd64/docs
           mkdir -p release/eventlist-linux-arm64/docs
-          mkdir -p release/eventlist-darwin-amd64/docs
           mkdir -p release/eventlist-darwin-arm64/docs
           mkdir -p release/eventlist-windows-amd64/docs
           mkdir -p release/eventlist-windows-arm64/docs
           cp LICENSE release/eventlist-linux-amd64/
           cp LICENSE release/eventlist-linux-arm64/
-          cp LICENSE release/eventlist-darwin-amd64/
           cp LICENSE release/eventlist-darwin-arm64/
           cp LICENSE release/eventlist-windows-amd64/
           cp LICENSE release/eventlist-windows-arm64/
           cp tools/eventlist/docs/* release/eventlist-linux-amd64/docs/
           cp tools/eventlist/docs/* release/eventlist-linux-arm64/docs/
-          cp tools/eventlist/docs/* release/eventlist-darwin-amd64/docs/
           cp tools/eventlist/docs/* release/eventlist-darwin-arm64/docs/
           cp tools/eventlist/docs/* release/eventlist-windows-amd64/docs/
           cp tools/eventlist/docs/* release/eventlist-windows-arm64/docs/
           cp tools/eventlist/third_party_licenses.md release/eventlist-linux-amd64/
           cp tools/eventlist/third_party_licenses.md release/eventlist-linux-arm64/
-          cp tools/eventlist/third_party_licenses.md release/eventlist-darwin-amd64/
           cp tools/eventlist/third_party_licenses.md release/eventlist-darwin-arm64/
           cp tools/eventlist/third_party_licenses.md release/eventlist-windows-amd64/
           cp tools/eventlist/third_party_licenses.md release/eventlist-windows-arm64/
@@ -339,12 +326,6 @@ jobs:
         with:
           name: eventlist-linux-arm64
           path: release/eventlist-linux-arm64/
-
-      - name: Download eventlist macos
-        uses: actions/download-artifact@v8
-        with:
-          name: eventlist-darwin-amd64
-          path: release/eventlist-darwin-amd64/
 
       - name: Download eventlist macos
         uses: actions/download-artifact@v8
@@ -374,7 +355,6 @@ jobs:
           zip -r eventlist-windows-arm64.zip eventlist-windows-arm64/eventlist.exe eventlist-windows-arm64/docs eventlist-windows-arm64/LICENSE eventlist-windows-arm64/third_party_licenses.md
           tar -czvf eventlist-linux-amd64.tar.gz  eventlist-linux-amd64/eventlist eventlist-linux-amd64/docs eventlist-linux-amd64/LICENSE eventlist-linux-amd64/third_party_licenses.md
           tar -czvf eventlist-linux-arm64.tar.gz  eventlist-linux-arm64/eventlist eventlist-linux-arm64/docs eventlist-linux-arm64/LICENSE eventlist-linux-arm64/third_party_licenses.md
-          tar -czvf eventlist-darwin-amd64.tar.gz eventlist-darwin-amd64/eventlist eventlist-darwin-amd64/docs eventlist-darwin-amd64/LICENSE eventlist-darwin-amd64/third_party_licenses.md
           tar -czvf eventlist-darwin-arm64.tar.gz eventlist-darwin-arm64/eventlist eventlist-darwin-arm64/docs eventlist-darwin-arm64/LICENSE eventlist-darwin-arm64/third_party_licenses.md
         working-directory: release
 
@@ -384,7 +364,6 @@ jobs:
           sha256sum eventlist-windows-arm64.zip --text >> eventlist-checksums.txt
           sha256sum eventlist-linux-amd64.tar.gz --text >> eventlist-checksums.txt
           sha256sum eventlist-linux-arm64.tar.gz --text >> eventlist-checksums.txt
-          sha256sum eventlist-darwin-amd64.tar.gz --text >> eventlist-checksums.txt
           sha256sum eventlist-darwin-arm64.tar.gz --text >> eventlist-checksums.txt
         working-directory: release
 

--- a/.github/workflows/eventlist.yml
+++ b/.github/workflows/eventlist.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     if: |
@@ -34,7 +37,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: tools/eventlist/go.mod
           cache: false
@@ -42,7 +45,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: github.event_name != 'release'
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: go
           queries: security-and-quality
@@ -54,7 +57,7 @@ jobs:
 
       - name: Perform CodeQL Analysis
         if: github.event_name != 'release'
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
 
       - name: Build remaining executables
         run: |
@@ -66,7 +69,7 @@ jobs:
         working-directory: ./tools/eventlist
 
       - name: Archive eventlist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: eventlist-linux-amd64
           path: ./tools/eventlist/build/linux-amd64
@@ -74,7 +77,7 @@ jobs:
           if-no-files-found: error
 
       - name: Archive eventlist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: eventlist-linux-arm64
           path: ./tools/eventlist/build/linux-arm64
@@ -82,7 +85,7 @@ jobs:
           if-no-files-found: error
 
       - name: Archive eventlist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: eventlist-darwin-amd64
           path: ./tools/eventlist/build/darwin-amd64
@@ -90,7 +93,7 @@ jobs:
           if-no-files-found: error
 
       - name: Archive eventlist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: eventlist-darwin-arm64
           path: ./tools/eventlist/build/darwin-arm64
@@ -98,7 +101,7 @@ jobs:
           if-no-files-found: error
 
       - name: Archive eventlist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: eventlist-windows-amd64
           path: ./tools/eventlist/build/windows-amd64
@@ -106,7 +109,7 @@ jobs:
           if-no-files-found: error
 
       - name: Archive eventlist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: eventlist-windows-arm64
           path: ./tools/eventlist/build/windows-arm64
@@ -123,7 +126,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: tools/eventlist/go.mod
           cache: false
@@ -146,7 +149,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: tools/eventlist/go.mod
           cache: false
@@ -171,6 +174,7 @@ jobs:
         with:
           go-version-file: ./tools/eventlist/go.mod
           check-latest: true
+          cache: false
           go-package: ./...
           work-dir: ./tools/eventlist
 
@@ -189,7 +193,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: tools/eventlist/go.mod
           cache: false
@@ -214,7 +218,7 @@ jobs:
           go-junit-report -set-exit-code -in build/evenlistunittest-${{ matrix.os }}.txt -iocopy -out build/evenlistunittest-${{ matrix.os }}.xml
 
       - name: Archive unit test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-test-result-${{ matrix.os }}
           path: ./tools/eventlist/build/evenlistunittest-*.xml
@@ -248,7 +252,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action/linux@v2
         with:
           report_individual_runs: true
-          junit_files: "testreports/*.xml"
+          files: "testreports/*.xml"
 
   coverage:
     if: |
@@ -262,7 +266,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: tools/eventlist/go.mod
           cache: false

--- a/.github/workflows/eventlist.yml
+++ b/.github/workflows/eventlist.yml
@@ -130,7 +130,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest
           skip-cache: true
           working-directory: ./tools/eventlist

--- a/.github/workflows/eventlist.yml
+++ b/.github/workflows/eventlist.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: tools/eventlist/go.mod
           check-latest: true
@@ -119,19 +119,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: tools/eventlist/go.mod
           check-latest: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest
+          skip-cache: true
           working-directory: ./tools/eventlist
 
   format:
@@ -140,10 +141,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: tools/eventlist/go.mod
           check-latest: true
@@ -182,10 +183,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: tools/eventlist/go.mod
           check-latest: true
@@ -222,19 +223,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download unit test report windows
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: unit-test-result-windows-2022
           path: testreports/
 
       - name: Download unit test report linux
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: unit-test-result-ubuntu-24.04
           path: testreports/
 
       - name: Download unit test report macos
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: unit-test-result-macos-14
           path: testreports/
@@ -255,10 +256,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: tools/eventlist/go.mod
           check-latest: true
@@ -290,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout devtools
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Create distribution folders
         run: |
@@ -320,37 +321,37 @@ jobs:
           cp tools/eventlist/third_party_licenses.md release/eventlist-windows-arm64/
 
       - name: Download eventlist linux
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: eventlist-linux-amd64
           path: release/eventlist-linux-amd64/
 
       - name: Download eventlist linux
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: eventlist-linux-arm64
           path: release/eventlist-linux-arm64/
 
       - name: Download eventlist macos
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: eventlist-darwin-amd64
           path: release/eventlist-darwin-amd64/
 
       - name: Download eventlist macos
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: eventlist-darwin-arm64
           path: release/eventlist-darwin-arm64/
 
       - name: Download eventlist windows
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: eventlist-windows-amd64
           path: release/eventlist-windows-amd64/
 
       - name: Download eventlist windows
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: eventlist-windows-arm64
           path: release/eventlist-windows-arm64/

--- a/.github/workflows/eventlist.yml
+++ b/.github/workflows/eventlist.yml
@@ -278,7 +278,7 @@ jobs:
           COVERAGE=$(go tool cover -func build/cover.out | tail -1 | awk '{print $3}' | tr -d '%')
           echo "Test Coverage: $COVERAGE%"
           COVERAGE_INT=$(echo "$COVERAGE * 10 / 1" | bc)
-          test "$COVERAGE_INT" -gt 92
+          test "$COVERAGE_INT" -ge 920
         working-directory: ./tools/eventlist
 
       # Temporarily disabled until we move on codeclimate

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,6 +21,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Single deploy job since we're just deploying
   deploy:

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -11,10 +11,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   pack:
     name: Generate pack
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/tpip-check.yml
+++ b/.github/workflows/tpip-check.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   tpip_report: "third_party_licenses.md"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   check-licenses:
@@ -22,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           cache-dependency-path: tools/eventlist/go.sum
           go-version-file: tools/eventlist/go.mod

--- a/tools/eventlist/.golangci.yaml
+++ b/tools/eventlist/.golangci.yaml
@@ -1,15 +1,21 @@
+version: "2"
+run:
+  build-tags:
+    - integration
 linters:
-    enable:
-        - errname
-        - errorlint
-        - goerr113
-        - makezero
-        - nilerr
-        - paralleltest
-        - prealloc
-        - predeclared
-        - revive
-        - thelper
-        - unconvert
-        - unparam
-        - wastedassign
+  default: none
+  enable:
+    - bodyclose
+    - errcheck
+    - gosec
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling

--- a/tools/eventlist/README.md
+++ b/tools/eventlist/README.md
@@ -68,7 +68,7 @@ The steps below demonstrate how to build and create an executable:
     for e.g.
 
     ```bash
-    ./make.sh build -arch amd64 -os darwin -outdir "Path/to/output/dir"
+    ./make.sh build -arch arm64 -os darwin -outdir "Path/to/output/dir"
     ```
 
 ## Run Tests

--- a/tools/eventlist/cmd/eventlist/main_test.go
+++ b/tools/eventlist/cmd/eventlist/main_test.go
@@ -84,7 +84,7 @@ func Test_includes_Set(t *testing.T) {
 	}
 }
 
-func Test_infoOpt(t *testing.T) { //nolint:golint,paralleltest
+func Test_infoOpt(t *testing.T) { //nolint:paralleltest
 	type args struct {
 		sopt string
 		lopt string
@@ -119,7 +119,7 @@ func Test_infoOpt(t *testing.T) { //nolint:golint,paralleltest
 			"  -a, --cd arg        unknown option\n"},
 	}
 	_ = flag.Set("test.run", "yy")
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			oldOut := os.Stdout
 			restore := func() {
@@ -138,7 +138,7 @@ func Test_infoOpt(t *testing.T) { //nolint:golint,paralleltest
 	}
 }
 
-func Test_main(t *testing.T) { //nolint:golint,paralleltest
+func Test_main(t *testing.T) { //nolint:paralleltest
 	outFile := "out.out"
 
 	lines1 :=
@@ -202,7 +202,7 @@ func Test_main(t *testing.T) { //nolint:golint,paralleltest
 		{"-I", []string{"-I", "../../testdata/nix", "xxx"}, ".*: open ../../testdata/nix: (no such file or directory|The system cannot find the file specified.)\\n", ""},
 	}
 	savedArgs := os.Args
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			oldOut := os.Stdout
 			restore := func() {

--- a/tools/eventlist/cmd/make/make.go
+++ b/tools/eventlist/cmd/make/make.go
@@ -63,23 +63,23 @@ type runner struct {
 }
 
 func (r runner) run(command string) {
-	switch {
-	case command == "build":
+	switch command {
+	case "build":
 		versionInfo, err := createResourceInfoFile(r.options.targetArch)
 		if err != nil {
 			fmt.Println(err.Error())
 			return
 		}
-		info := versionInfo.StringFileInfo.FileVersion + " " + versionInfo.StringFileInfo.LegalCopyright
+		info := versionInfo.StringFileInfo.FileVersion + " " + versionInfo.LegalCopyright
 		if err = r.build(r.options, info); err != nil {
 			fmt.Println(err.Error())
 		}
-	case command == "test":
+	case "test":
 		if err := r.test(); err != nil {
 			fmt.Println(err.Error())
 			return
 		}
-	case command == "coverage":
+	case "coverage":
 		if r.options.covReport == "" {
 			if err := r.coverage(); err != nil {
 				fmt.Println(err.Error())
@@ -91,9 +91,9 @@ func (r runner) run(command string) {
 				return
 			}
 		}
-	case command == "lint":
+	case "lint":
 		r.lint()
-	case command == "format":
+	case "format":
 		r.format()
 	}
 }
@@ -233,7 +233,7 @@ func createResourceInfoFile(arch string) (version goversioninfo.VersionInfo, err
 		ProductVersion:   gitVersion.String(),
 		LegalCopyright:   "Copyright (c) 2022-" + gitYear + " " + legalCopyright,
 	}
-	verInfo.VarFileInfo.Translation = goversioninfo.Translation{
+	verInfo.Translation = goversioninfo.Translation{
 		LangID:    1033,
 		CharsetID: 1200,
 	}
@@ -291,7 +291,7 @@ func newVersion(verStr string) (ver version, err error) {
 	tokens := strings.Split(versionStr, "-")
 	numTokens := len(tokens)
 
-	if !(numTokens == 1 || numTokens == 3) {
+	if numTokens != 1 && numTokens != 3 {
 		return ver, reportError(ErrVersion, "invalid version string")
 	}
 	verParts := strings.Split(tokens[0], ".")

--- a/tools/eventlist/go.mod
+++ b/tools/eventlist/go.mod
@@ -1,8 +1,7 @@
 module eventlist
 
-go 1.20
+go 1.26
 
-require (
-	github.com/akavel/rsrc v0.10.2 // indirect
-	github.com/josephspurrier/goversioninfo v1.4.0
-)
+require github.com/josephspurrier/goversioninfo v1.4.0
+
+require github.com/akavel/rsrc v0.10.2 // indirect

--- a/tools/eventlist/go.sum
+++ b/tools/eventlist/go.sum
@@ -1,11 +1,14 @@
-github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/akavel/rsrc v0.10.2 h1:Zxm8V5eI1hW4gGaYsJQUhxpjkENuG91ki8B4zCrvEsw=
 github.com/akavel/rsrc v0.10.2/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/josephspurrier/goversioninfo v1.4.0 h1:Puhl12NSHUSALHSuzYwPYQkqa2E1+7SrtAPJorKK0C8=
 github.com/josephspurrier/goversioninfo v1.4.0/go.mod h1:JWzv5rKQr+MmW+LvM412ToT/IkYDZjaclF2pKDss8IY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/eventlist/pkg/elf/elf.go
+++ b/tools/eventlist/pkg/elf/elf.go
@@ -103,8 +103,13 @@ func (s *sections) Readelf(name *string) error {
 func (s *sections) GetString(addr uint64) string {
 	for _, es := range s.sections {
 		if addr >= es.addr && addr < es.addr+uint64(len(es.data)) {
-			l := strings.IndexByte(string(es.data[addr-es.addr:]), 0)
-			return string(es.data[addr-es.addr : addr-es.addr+uint64(l)])
+			start := addr - es.addr
+			data := es.data[start:]
+			l := strings.IndexByte(string(data), 0)
+			if l < 0 {
+				return string(data)
+			}
+			return string(data[:l])
 		}
 	}
 	return ""

--- a/tools/eventlist/pkg/elf/elf_test.go
+++ b/tools/eventlist/pkg/elf/elf_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 )
 
-func Test_sections_Readelf(t *testing.T) { //nolint:golint,paralleltest
+func Test_sections_Readelf(t *testing.T) { //nolint:paralleltest
 	fileTest := "../../testdata/elftest.elf"
 	fileNix := "../../testdata/nix.elf"
 	fileSym := "../../testdata/elfsym.elf"
@@ -43,7 +43,7 @@ func Test_sections_Readelf(t *testing.T) { //nolint:golint,paralleltest
 		{"test", &sections{}, args{name: &fileTest}, 0, false},
 		{"errName", &sections{}, args{name: &fileNix}, 0, true},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 			if err = tt.s.Readelf(tt.args.name); (err != nil) != tt.wantErr {

--- a/tools/eventlist/pkg/eval/eval.go
+++ b/tools/eventlist/pkg/eval/eval.go
@@ -87,7 +87,7 @@ func GetIdValue(id string, typedefs Typedefs) (uint16, error) { //nolint:revive
 	}
 	value := n.GetInt()
 	if value < 0 || value > math.MaxUint16 {
-		return 0, typeError("ID", "")
+		return 0, rangeError("ID", id)
 	}
 	return uint16(value), nil
 }

--- a/tools/eventlist/pkg/eval/eval.go
+++ b/tools/eventlist/pkg/eval/eval.go
@@ -20,6 +20,7 @@ package eval
 
 import (
 	"errors"
+	"math"
 )
 
 type Member struct {
@@ -79,10 +80,14 @@ func GetValue(value string, typedefs Typedefs) (int64, error) {
 // GetIdValue evaluates the ID and returns its value as an IDType(uint16).
 // If an error occurs during evaluation, it returns 0 and the error.
 // It ignores eval.ErrEof.
-func GetIdValue(id string, typedefs Typedefs) (uint16, error) { //nolint:golint,revive
+func GetIdValue(id string, typedefs Typedefs) (uint16, error) { //nolint:revive
 	n, err := Eval(&id, typedefs, nil)
 	if err != nil && !errors.Is(err, ErrEof) {
 		return 0, err
 	}
-	return uint16(n.GetInt()), nil
+	value := n.GetInt()
+	if value < 0 || value > math.MaxUint16 {
+		return 0, typeError("ID", "")
+	}
+	return uint16(value), nil
 }

--- a/tools/eventlist/pkg/eval/eval_test.go
+++ b/tools/eventlist/pkg/eval/eval_test.go
@@ -65,7 +65,7 @@ func TestEval(t *testing.T) {
 	}
 }
 
-func TestGetValue(t *testing.T) { //nolint:golint,paralleltest
+func TestGetValue(t *testing.T) { //nolint:paralleltest
 	var tds = make(Typedefs)
 
 	type args struct {
@@ -81,7 +81,7 @@ func TestGetValue(t *testing.T) { //nolint:golint,paralleltest
 		{"GetInfo", args{"1+1", tds}, 2, false},
 		{"GetInfo err", args{"??", tds}, 0, true},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GetValue(tt.args.value, tt.args.typedefs)
 			if (err != nil) != tt.wantErr {
@@ -95,7 +95,7 @@ func TestGetValue(t *testing.T) { //nolint:golint,paralleltest
 	}
 }
 
-func TestGetIdValue(t *testing.T) { //nolint:golint,paralleltest
+func TestGetIdValue(t *testing.T) { //nolint:paralleltest
 	id1 := "2+3"
 	id2 := "=="
 	var tds = make(Typedefs)
@@ -113,7 +113,7 @@ func TestGetIdValue(t *testing.T) { //nolint:golint,paralleltest
 		{"getIdValue", args{id1, tds}, 5, false},
 		{"getIdValue err", args{id2, tds}, 0, true},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GetIdValue(tt.args.id, tt.args.typedefs)
 			if (err != nil) != tt.wantErr {

--- a/tools/eventlist/pkg/eval/expression.go
+++ b/tools/eventlist/pkg/eval/expression.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"math"
 	"strings"
+	"unicode/utf8"
 )
 
 const maxUint64 = 1<<64 - 1
@@ -170,7 +171,7 @@ var ErrSyntax = errors.New("syntax error")
 
 var ErrType = errors.New("value type error")
 
-var ErrEof = errors.New("eof") //nolint:golint,revive
+var ErrEof = errors.New("eof") //nolint:revive
 
 type NumError struct {
 	Func string // failing function
@@ -281,7 +282,7 @@ func (ex *Expression) parseUint() (uint64, error) {
 		if c, err = ex.get(); err != nil {
 			// err could only be an EOF which is corrrect here
 			// only a '0'
-			return 0, nil //nolint:golint,nilerr
+			return 0, nil //nolint:nilerr
 		}
 		if lower(c) == 'x' {
 			s0 += string(c)
@@ -630,7 +631,7 @@ func (ex *Expression) lex() (Value, error) {
 			}
 			return Value{t: Floating, f: f}, nil
 		}
-		return Value{t: Integer, i: int64(ui)}, nil
+		return Value{t: Integer, i: int64FromUint64(ui)}, nil
 
 	} else if 'a' <= lower(c) && lower(c) <= 'z' {
 	loop:
@@ -660,7 +661,8 @@ func (ex *Expression) lex() (Value, error) {
 			}
 			s0 += string(c)
 			done := false
-			if c == '\\' {
+			switch c {
+			case '\\':
 				var cx byte
 				if c, err = ex.get(); err != nil {
 					return v, syntaxError(fnLex, s0)
@@ -728,10 +730,14 @@ func (ex *Expression) lex() (Value, error) {
 						return v, syntaxError(fnLex, s0)
 					}
 					s0 += s
-					v.s += string(rune(i))
+					r := runeFromUint32(i)
+					if !utf8.ValidRune(r) {
+						r = utf8.RuneError
+					}
+					v.s += string(r)
 					done = true
 				}
-			} else if c == '"' {
+			case '"':
 				v.t = String
 				return v, nil
 			}
@@ -1086,7 +1092,11 @@ func (ex *Expression) postfix() (Value, error) { // TODO: not finished yet
 				if !right.IsInteger() {
 					return right, syntaxError("integer offset expected", "")
 				}
-				if err = v.Extract(members.Size, members.BigEndian, uint32(right.i)); err != nil {
+				offset, ok := uint32FromInt64(right.i)
+				if !ok {
+					return right, typeError("Extract", "invalid offset")
+				}
+				if err = v.Extract(members.Size, members.BigEndian, offset); err != nil {
 					return v, err
 				}
 				if err = v.Cast(member.IType); err != nil {

--- a/tools/eventlist/pkg/eval/expression.go
+++ b/tools/eventlist/pkg/eval/expression.go
@@ -721,7 +721,11 @@ func (ex *Expression) lex() (Value, error) {
 						return v, syntaxError(fnLex, s0)
 					}
 					s0 += s
-					v.s += string(rune(i))
+					r := rune(i)
+					if !utf8.ValidRune(r) {
+						r = utf8.RuneError
+					}
+					v.s += string(r)
 					done = true
 				case 'U':
 					var s string

--- a/tools/eventlist/pkg/eval/expression_test.go
+++ b/tools/eventlist/pkg/eval/expression_test.go
@@ -778,7 +778,7 @@ func TestExpression_arguments(t *testing.T) {
 	}
 }
 
-func TestExpression_postfix(t *testing.T) { //nolint:golint,paralleltest
+func TestExpression_postfix(t *testing.T) { //nolint:paralleltest
 	var s0 = "++ +"
 	var s1 = "++$"
 	var s2 = "++"
@@ -873,7 +873,7 @@ func TestExpression_postfix(t *testing.T) { //nolint:golint,paralleltest
 		{"Index_name_err", fields{&s27, 0, Value{t: Identifier, s: "name"}, nil, nil}, Value{t: Identifier, s: "name"}, false, true},
 	}
 
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			ex := &Expression{
 				in:       tt.fields.in,

--- a/tools/eventlist/pkg/eval/value.go
+++ b/tools/eventlist/pkg/eval/value.go
@@ -21,6 +21,8 @@ package eval
 import (
 	"encoding/binary"
 	"eventlist/pkg/elf"
+	"math"
+	"unicode/utf8"
 	"unsafe"
 )
 
@@ -31,6 +33,45 @@ type Value struct {
 	s string
 	v *Variable
 	l []Value
+}
+
+func int64FromUint64(value uint64) int64 {
+	return *(*int64)(unsafe.Pointer(&value))
+}
+
+func uint64FromInt64(value int64) uint64 {
+	return *(*uint64)(unsafe.Pointer(&value))
+}
+
+func uint32FromInt64(value int64) (uint32, bool) {
+	if value < 0 || value > math.MaxUint32 {
+		return 0, false
+	}
+	return uint32(value), true
+}
+
+func uint64Low(value int64, bits uint) uint64 {
+	return uint64FromInt64(value) & ((uint64(1) << bits) - 1)
+}
+
+func int64FromSmallUint(value uint64) int64 {
+	return int64FromUint64(value)
+}
+
+func int64FromUint(value int64, bits uint) int64 {
+	unsigned := uint64Low(value, bits)
+	result := int64FromSmallUint(unsigned)
+	if result >= int64FromSmallUint(uint64(1)<<(bits-1)) {
+		result -= int64FromSmallUint(uint64(1) << bits)
+	}
+	return result
+}
+
+func runeFromUint32(value uint32) rune {
+	if value > utf8.MaxRune {
+		return utf8.RuneError
+	}
+	return rune(value)
 }
 
 // Compose sets the fields of the Value struct with the provided parameters.
@@ -121,7 +162,7 @@ func (v *Value) GetInt() int64 {
 func (v *Value) GetUInt() uint64 {
 	switch v.t {
 	case Integer:
-		return uint64(v.i)
+		return uint64FromInt64(v.i)
 	case Floating:
 		return uint64(v.f)
 	}
@@ -267,14 +308,14 @@ func (v *Value) Function(v1 *Value) error {
 	case OFFSETOF:
 		a, _, flag := elf.Symbols.GetAddrSize(v1.GetList()[0].s)
 		if flag {
-			*v = Value{t: f.ret, i: int64(a)}
+			*v = Value{t: f.ret, i: int64FromUint64(a)}
 		} else {
 			*v = Value{t: f.ret, i: 0}
 		}
 	case SIZEOF:
 		_, s, flag := elf.Symbols.GetAddrSize(v1.GetList()[0].s)
 		if flag {
-			*v = Value{t: f.ret, i: int64(s)}
+			*v = Value{t: f.ret, i: int64FromUint64(s)}
 		} else {
 			*v = Value{t: f.ret, i: 0}
 		}
@@ -307,14 +348,14 @@ func (v *Value) Extract(sz uint32, bigEndian bool, off uint32) error {
 	if off >= sz {
 		return typeError("Extract", "invalid offset")
 	}
-	tmp := uint64(v.i)
+	tmp := uint64FromInt64(v.i)
 	if bigEndian {
 		tmp = binary.BigEndian.Uint64((*[8]byte)(unsafe.Pointer(&tmp))[:])
 		tmp >>= 64 - sz*8
 	}
 	tmp &= (uint64(1) << (sz * 8)) - 1
 	tmp >>= off * 8
-	v.i = int64(tmp)
+	v.i = int64FromUint64(tmp)
 	return nil
 }
 
@@ -438,7 +479,7 @@ func (v *Value) Cast(ty Type) error {
 	case Uint8:
 		switch v.t {
 		case Integer:
-			v.i = int64(uint8(v.i))
+			v.i = int64FromSmallUint(uint64Low(v.i, 8))
 		case Floating:
 			v.i = int64(uint8(v.f))
 			v.t = Integer
@@ -449,7 +490,7 @@ func (v *Value) Cast(ty Type) error {
 	case Int8:
 		switch v.t {
 		case Integer:
-			v.i = int64(int8(v.i))
+			v.i = int64FromUint(v.i, 8)
 		case Floating:
 			v.i = int64(int8(v.f))
 			v.t = Integer
@@ -460,7 +501,7 @@ func (v *Value) Cast(ty Type) error {
 	case Uint16:
 		switch v.t {
 		case Integer:
-			v.i = int64(uint16(v.i))
+			v.i = int64FromSmallUint(uint64Low(v.i, 16))
 		case Floating:
 			v.i = int64(uint16(v.f))
 			v.t = Integer
@@ -471,7 +512,7 @@ func (v *Value) Cast(ty Type) error {
 	case Int16:
 		switch v.t {
 		case Integer:
-			v.i = int64(int16(v.i))
+			v.i = int64FromUint(v.i, 16)
 		case Floating:
 			v.i = int64(int16(v.f))
 			v.t = Integer
@@ -482,7 +523,7 @@ func (v *Value) Cast(ty Type) error {
 	case Uint32:
 		switch v.t {
 		case Integer:
-			v.i = int64(uint32(v.i))
+			v.i = int64FromSmallUint(uint64Low(v.i, 32))
 		case Floating:
 			v.i = int64(uint32(v.f))
 			v.t = Integer
@@ -493,7 +534,7 @@ func (v *Value) Cast(ty Type) error {
 	case Int32:
 		switch v.t {
 		case Integer:
-			v.i = int64(int32(v.i))
+			v.i = int64FromUint(v.i, 32)
 		case Floating:
 			v.i = int64(int32(v.f))
 			v.t = Integer
@@ -504,9 +545,9 @@ func (v *Value) Cast(ty Type) error {
 	case Uint64:
 		switch v.t {
 		case Integer:
-			v.i = int64(uint64(v.i))
+			// already stored as the two's-complement bit pattern
 		case Floating:
-			v.i = int64(uint64(v.f))
+			v.i = int64FromUint64(uint64(v.f))
 			v.t = Integer
 			v.f = 0
 		default:

--- a/tools/eventlist/pkg/eval/value_test.go
+++ b/tools/eventlist/pkg/eval/value_test.go
@@ -70,7 +70,7 @@ func TestValue_Compose(t *testing.T) {
 	}
 }
 
-func TestValue_getValue(t *testing.T) { //nolint:golint,paralleltest
+func TestValue_getValue(t *testing.T) { //nolint:paralleltest
 	vari := Variable{"v1_getValue", Value{t: Integer, i: 456}}
 
 	type fields struct {
@@ -93,7 +93,7 @@ func TestValue_getValue(t *testing.T) { //nolint:golint,paralleltest
 		{"test_error1", fields{t: Integer, v: &vari}, true, Value{}, true},
 	}
 
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			v := &Value{
 				t: tt.fields.t,
@@ -120,7 +120,7 @@ func TestValue_getValue(t *testing.T) { //nolint:golint,paralleltest
 	}
 }
 
-func TestValue_setValue(t *testing.T) { //nolint:golint,paralleltest
+func TestValue_setValue(t *testing.T) { //nolint:paralleltest
 	vari := Variable{"v1_setValue", Value{t: Integer, i: 456}}
 	val1 := Value{t: Integer, i: 123}
 
@@ -147,7 +147,7 @@ func TestValue_setValue(t *testing.T) { //nolint:golint,paralleltest
 		{"test_error", fields{t: Identifier}, args{&val1}, true, &Value{}, true},
 		{"test_error1", fields{t: Identifier, v: &vari}, args{&val1}, true, &Value{}, true},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			v := &Value{
 				t: tt.fields.t,
@@ -556,7 +556,7 @@ func TestValue_IsList(t *testing.T) {
 	}
 }
 
-func TestValue_Function(t *testing.T) { //nolint:golint,paralleltest
+func TestValue_Function(t *testing.T) { //nolint:paralleltest
 	calcMemUsedArgs := Value{t: List, l: []Value{{t: Integer, i: 1}, {t: Integer, i: 2}, {t: Integer, i: 3}, {t: Integer, i: 4}}}
 	calcMemUsedArgs1 := Value{t: List, l: []Value{{t: String}, {t: Integer, i: 2}, {t: Integer, i: 3}, {t: Integer, i: 4}}}
 	getRegValArgs := Value{t: List, l: []Value{{t: String, s: "reg"}}}
@@ -600,7 +600,7 @@ func TestValue_Function(t *testing.T) { //nolint:golint,paralleltest
 		{"wrongCnt", fields{t: Identifier, s: "__CalcMemUsed"}, args{&getRegValArgs}, Value{t: Identifier, s: "__CalcMemUsed"}, true},
 		{"wrongType", fields{t: Identifier, s: "__CalcMemUsed"}, args{&calcMemUsedArgs1}, Value{t: Identifier, s: "__CalcMemUsed"}, true},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			v := &Value{
 				t: tt.fields.t,

--- a/tools/eventlist/pkg/eval/variable_test.go
+++ b/tools/eventlist/pkg/eval/variable_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-//nolint:golint,paralleltest
+//nolint:paralleltest
 package eval
 
 import (

--- a/tools/eventlist/pkg/event/event.go
+++ b/tools/eventlist/pkg/event/event.go
@@ -30,7 +30,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"unsafe"
 )
 
 var errEnum = errors.New("invalid enum")
@@ -38,11 +37,11 @@ var errEnum = errors.New("invalid enum")
 var errFormat = errors.New("invalid format expression")
 
 func uint32FromInt32(value int32) uint32 {
-	return *(*uint32)(unsafe.Pointer(&value))
+	return uint32(value) //nolint:gosec // preserve the two's-complement bit pattern
 }
 
 func int32FromUint32(value uint32) int32 {
-	return *(*int32)(unsafe.Pointer(&value))
+	return int32(value) //nolint:gosec // preserve the two's-complement bit pattern
 }
 
 // enumError creates and returns a pointer to an eval.NumError struct.

--- a/tools/eventlist/pkg/event/event.go
+++ b/tools/eventlist/pkg/event/event.go
@@ -30,11 +30,20 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"unsafe"
 )
 
 var errEnum = errors.New("invalid enum")
 
 var errFormat = errors.New("invalid format expression")
+
+func uint32FromInt32(value int32) uint32 {
+	return *(*uint32)(unsafe.Pointer(&value))
+}
+
+func int32FromUint32(value uint32) int32 {
+	return *(*int32)(unsafe.Pointer(&value))
+}
 
 // enumError creates and returns a pointer to an eval.NumError struct.
 // The function takes two string parameters: fn and str, which represent
@@ -409,10 +418,10 @@ func (e *Data) GetValuesAsString() string {
 		}
 		return sb.String()
 	case 2: // Eventrecord2
-		return fmt.Sprintf("val1=0x%08x, val2=0x%08x", uint32(e.Value1), uint32(e.Value2))
+		return fmt.Sprintf("val1=0x%08x, val2=0x%08x", uint32FromInt32(e.Value1), uint32FromInt32(e.Value2))
 	case 3: // Eventrecord4
 		return fmt.Sprintf("val1=0x%08x, val2=0x%08x, val3=0x%08x, val4=0x%08x",
-			uint32(e.Value1), uint32(e.Value2), uint32(e.Value3), uint32(e.Value4))
+			uint32FromInt32(e.Value1), uint32FromInt32(e.Value2), uint32FromInt32(e.Value3), uint32FromInt32(e.Value4))
 	}
 	return ""
 }
@@ -529,16 +538,16 @@ func (e *Data) Read(in *bufio.Reader) error {
 		if len(data) < 20 {
 			return eval.ErrEof
 		}
-		e.Value1 = int32(convert32(data[12:16]))
-		e.Value2 = int32(convert32(data[16:20]))
+		e.Value1 = int32FromUint32(convert32(data[12:16]))
+		e.Value2 = int32FromUint32(convert32(data[16:20]))
 	case 3: // Eventrecord4
 		if len(data) < 28 {
 			return eval.ErrEof
 		}
-		e.Value1 = int32(convert32(data[12:16]))
-		e.Value2 = int32(convert32(data[16:20]))
-		e.Value3 = int32(convert32(data[20:24]))
-		e.Value4 = int32(convert32(data[24:28]))
+		e.Value1 = int32FromUint32(convert32(data[12:16]))
+		e.Value2 = int32FromUint32(convert32(data[16:20]))
+		e.Value3 = int32FromUint32(convert32(data[20:24]))
+		e.Value4 = int32FromUint32(convert32(data[24:28]))
 	}
 	return nil
 }

--- a/tools/eventlist/pkg/event/event_test.go
+++ b/tools/eventlist/pkg/event/event_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 )
 
-func Test_getEnum(t *testing.T) { //nolint:golint,paralleltest
+func Test_getEnum(t *testing.T) { //nolint:paralleltest
 	var vals eval.Member
 	vals.Enums = make(map[int64]string)
 	var td eval.ITypedef
@@ -63,7 +63,7 @@ func Test_getEnum(t *testing.T) { //nolint:golint,paralleltest
 		{"enum err6", args{tds, 47, "typName:enumName]", &i}, "", 8, true},
 		{"enum err7", args{tds, 4711, "typName]", &i}, "enum", 8, false},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			i = 0
 			got, err := getEnum(tt.args.typedefs, tt.args.val, tt.args.value, tt.args.i)
@@ -168,7 +168,7 @@ func TestInfo_SplitID(t *testing.T) {
 	}
 }
 
-func TestEventData_calculateExpression(t *testing.T) { //nolint:golint,paralleltest
+func TestEventData_calculateExpression(t *testing.T) { //nolint:paralleltest
 	var i int
 
 	fileTest := "../../testdata/elftest.elf"
@@ -223,7 +223,7 @@ func TestEventData_calculateExpression(t *testing.T) { //nolint:golint,parallelt
 		t.Errorf("Data.calculateExpression() cannot open %s", fileTest)
 		return
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			e := &Data{
 				Time:   tt.fields.Time,
@@ -250,7 +250,7 @@ func TestEventData_calculateExpression(t *testing.T) { //nolint:golint,parallelt
 	}
 }
 
-func TestEventData_calculateEnumExpression(t *testing.T) { //nolint:golint,paralleltest
+func TestEventData_calculateEnumExpression(t *testing.T) { //nolint:paralleltest
 	var vals eval.Member
 	vals.Enums = make(map[int64]string)
 	var td eval.ITypedef
@@ -301,7 +301,7 @@ func TestEventData_calculateEnumExpression(t *testing.T) { //nolint:golint,paral
 		{"enumExpr err3", ed1, args{tds, "E[val3, xxx]", &i}, "", 12, true},
 		{"enumExpr err4", ed1, args{tds, "S[val3, xxx]", &i}, "", 7, true},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			e := &Data{
 				Time:   tt.fields.Time,
@@ -331,14 +331,14 @@ func TestEventData_calculateEnumExpression(t *testing.T) { //nolint:golint,paral
 func TestEventData_EvalLine(t *testing.T) {
 	t.Parallel()
 
-	var ev1 scvd.EventType = scvd.EventType{ID: "id1", Value: "x%%%d[val1]y%u[val2]z"}
-	var ev2 scvd.EventType = scvd.EventType{ID: "id2", Value: "x%T[val1]y%x[val2]z"}
-	var ev3 scvd.EventType = scvd.EventType{ID: "id3", Value: "x%I[val3]y%J[val3]z"}
-	var ev4 scvd.EventType = scvd.EventType{ID: "id4", Value: "x%M[val3]y%S[val3]z"}
-	var evE1 scvd.EventType = scvd.EventType{ID: "idE1", Value: "x%E[val2, typName]y"}
-	var evTD scvd.EventType = scvd.EventType{ID: "idTD", Val1: "v1", Val2: "v2", Val3: "4BY", Val4: "v4", Val5: "v5", Val6: "v6", Value: "x%x[val3.B2]y"}
-	var everr1 scvd.EventType = scvd.EventType{ID: "iderr1", Value: "x%d[;]y"}
-	var everr2 scvd.EventType = scvd.EventType{ID: "iderr2", Value: "x%E[;]y"}
+	var ev1 = scvd.EventType{ID: "id1", Value: "x%%%d[val1]y%u[val2]z"}
+	var ev2 = scvd.EventType{ID: "id2", Value: "x%T[val1]y%x[val2]z"}
+	var ev3 = scvd.EventType{ID: "id3", Value: "x%I[val3]y%J[val3]z"}
+	var ev4 = scvd.EventType{ID: "id4", Value: "x%M[val3]y%S[val3]z"}
+	var evE1 = scvd.EventType{ID: "idE1", Value: "x%E[val2, typName]y"}
+	var evTD = scvd.EventType{ID: "idTD", Val1: "v1", Val2: "v2", Val3: "4BY", Val4: "v4", Val5: "v5", Val6: "v6", Value: "x%x[val3.B2]y"}
+	var everr1 = scvd.EventType{ID: "iderr1", Value: "x%d[;]y"}
+	var everr2 = scvd.EventType{ID: "iderr2", Value: "x%E[;]y"}
 
 	var vals eval.Member
 	vals.Enums = make(map[int64]string)
@@ -625,7 +625,7 @@ func TestEventData_Read(t *testing.T) {
 	}
 }
 
-func TestData_GetValue(t *testing.T) { //nolint:golint,paralleltest
+func TestData_GetValue(t *testing.T) { //nolint:paralleltest
 	type fields struct {
 		Time   uint64
 		Value1 int32
@@ -686,7 +686,7 @@ func TestData_GetValue(t *testing.T) { //nolint:golint,paralleltest
 		{"nixvar", ed2, args{"xx", &i, tds}, 42, eval.Value{}, true},
 		{"valxxx", ed1, args{"[valxxx]", &i, tds}, 42, eval.Value{}, true},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			i = 0
 			e := &Data{

--- a/tools/eventlist/pkg/output/output.go
+++ b/tools/eventlist/pkg/output/output.go
@@ -535,7 +535,7 @@ func (o *Output) printStatistic(out *bufio.Writer, eventCount int, eventTable *E
 						TextMaxB:    o.evProps[i].values[j].textMaxB,
 						TextMaxE:    o.evProps[i].values[j].textMaxE,
 					}
-					err = conditionalWrite(out, eventStat.Event)
+					err = conditionalWrite(out, "%s", eventStat.Event)
 					if err == nil && j < 10 {
 						err = conditionalWrite(out, " ")
 					}

--- a/tools/eventlist/pkg/output/output.go
+++ b/tools/eventlist/pkg/output/output.go
@@ -261,7 +261,7 @@ func (ep *eventProperty) getAddCount(idx uint16) string {
 // Returns:
 //
 //	A string representing the value `v` with the appropriate unit prefix.
-func convertUnit(v float64, unit string) string { //nolint:golint,unparam
+func convertUnit(v float64, unit string) string { //nolint:unparam
 	switch {
 	case v >= 1e9:
 		unit = "G" + unit
@@ -619,7 +619,7 @@ func escapeGen(s string) string {
 			t += "\\v"
 		default:
 			if c < ' ' {
-				t += fmt.Sprintf("\\%03o", byte(c))
+				t += fmt.Sprintf("\\%03o", c)
 			} else {
 				t += string(c)
 			}

--- a/tools/eventlist/pkg/output/output_test.go
+++ b/tools/eventlist/pkg/output/output_test.go
@@ -34,7 +34,7 @@ import (
 	"testing"
 )
 
-func TestTimeInSecs(t *testing.T) { //nolint:golint,paralleltest
+func TestTimeInSecs(t *testing.T) { //nolint:paralleltest
 	type args struct {
 		time uint64
 	}
@@ -47,7 +47,7 @@ func TestTimeInSecs(t *testing.T) { //nolint:golint,paralleltest
 		{"clear", args{77}, true, 4e-8 * 77},
 		{"set", args{47}, false, 2.0 * 47},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.clear {
 				TimeFactor = nil
@@ -603,7 +603,7 @@ func Test_eventProperty_getLast(t *testing.T) {
 	}
 }
 
-func TestOutput_buildStatistic(t *testing.T) { //nolint:golint,paralleltest
+func TestOutput_buildStatistic(t *testing.T) { //nolint:paralleltest
 	eds0 := make(scvd.Events)
 	eds := make(scvd.Events)
 	eds[0xEF00] = scvd.EventType{Brief: "briefbriefbrief", Property: "propertypropertyproperty", Value: "value"}
@@ -643,7 +643,7 @@ func TestOutput_buildStatistic(t *testing.T) { //nolint:golint,paralleltest
 		{"test7a", fields{[4]eventProperty{}, []string{"Index", "Time (s)", "Component", "Event Property", "Value"}, 0, 0}, args{s7, eds0, tds}, 1, 9, 14, 0.25},
 		{"test7b", fields{[4]eventProperty{}, []string{"Index", "Time (s)", "Component", "Event Property", "Value"}, 0, 0}, args{s7, eds, tds}, 1, 15, 24, 0.25},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			o := &Output{
 				evProps:       tt.fields.evProps,
@@ -668,7 +668,7 @@ func TestOutput_buildStatistic(t *testing.T) { //nolint:golint,paralleltest
 	}
 }
 
-func TestOutput_printStatistic(t *testing.T) { //nolint:golint,paralleltest
+func TestOutput_printStatistic(t *testing.T) { //nolint:paralleltest
 	var b bytes.Buffer
 
 	props0 := [4]eventProperty{}
@@ -706,7 +706,7 @@ func TestOutput_printStatistic(t *testing.T) { //nolint:golint,paralleltest
 		Events:     []EventRecord{},
 		Statistics: []EventRecordStatistic{},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.out = bufio.NewWriter(&b)
 			o := &Output{
@@ -764,7 +764,7 @@ func Test_escapeGen(t *testing.T) {
 	}
 }
 
-func TestOutput_printEvents(t *testing.T) { //nolint:golint,paralleltest
+func TestOutput_printEvents(t *testing.T) { //nolint:paralleltest
 	var b bytes.Buffer
 
 	eds := make(scvd.Events)
@@ -815,7 +815,7 @@ func TestOutput_printEvents(t *testing.T) { //nolint:golint,paralleltest
 		Events:     []EventRecord{},
 		Statistics: []EventRecordStatistic{},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.out = bufio.NewWriter(&b)
 
@@ -843,7 +843,7 @@ func TestOutput_printEvents(t *testing.T) { //nolint:golint,paralleltest
 	}
 }
 
-func TestOutput_printHeader(t *testing.T) { //nolint:golint,paralleltest
+func TestOutput_printHeader(t *testing.T) { //nolint:paralleltest
 	var b bytes.Buffer
 
 	type fields struct {
@@ -864,7 +864,7 @@ func TestOutput_printHeader(t *testing.T) { //nolint:golint,paralleltest
 	}{
 		{"test", fields{columns: []string{"a", "b", "c", "d", "e"}, componentSize: 15, propertySize: 20}, args{}, "c", "d"},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.out = bufio.NewWriter(&b)
 			o := &Output{
@@ -906,7 +906,7 @@ func TestOutput_printHeader(t *testing.T) { //nolint:golint,paralleltest
 	}
 }
 
-func TestOutput_print(t *testing.T) { //nolint:golint,paralleltest
+func TestOutput_print(t *testing.T) { //nolint:paralleltest
 	var b bytes.Buffer
 
 	//	var e0 = "../../testdata/test.xml"
@@ -965,7 +965,7 @@ func TestOutput_print(t *testing.T) { //nolint:golint,paralleltest
 		Events:     []EventRecord{},
 		Statistics: []EventRecordStatistic{},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.out = bufio.NewWriter(&b)
 
@@ -991,7 +991,7 @@ func TestOutput_print(t *testing.T) { //nolint:golint,paralleltest
 	}
 }
 
-func TestPrint(t *testing.T) { //nolint:golint,paralleltest
+func TestPrint(t *testing.T) { //nolint:paralleltest
 	o1 := "testOutput.out"
 
 	var s10 = "../../testdata/test10.binary"
@@ -1028,7 +1028,7 @@ func TestPrint(t *testing.T) { //nolint:golint,paralleltest
 	}{
 		{"test", args{filename: &o1, eventFile: &s10}, false},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			TimeFactor = nil
 			defer os.Remove(*tt.args.filename)
@@ -1068,7 +1068,7 @@ func TestPrint(t *testing.T) { //nolint:golint,paralleltest
 	}
 }
 
-func TestPrintJSON(t *testing.T) { //nolint:golint,paralleltest
+func TestPrintJSON(t *testing.T) { //nolint:paralleltest
 	o1 := "testOutput.json"
 
 	var s10 = "../../testdata/test10.binary"
@@ -1094,7 +1094,7 @@ func TestPrintJSON(t *testing.T) { //nolint:golint,paralleltest
 	}{
 		{"test1", args{filename: &o1, eventFile: &s10}, false},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			TimeFactor = nil
 			defer os.Remove(*tt.args.filename)
@@ -1130,7 +1130,7 @@ func TestPrintJSON(t *testing.T) { //nolint:golint,paralleltest
 	}
 }
 
-func TestPrintXML(t *testing.T) { //nolint:golint,paralleltest
+func TestPrintXML(t *testing.T) { //nolint:paralleltest
 	o1 := "testOutput.xml"
 
 	var s10 = "../../testdata/test10.binary"
@@ -1156,7 +1156,7 @@ func TestPrintXML(t *testing.T) { //nolint:golint,paralleltest
 	}{
 		{"test", args{filename: &o1, eventFile: &s10}, false},
 	}
-	for _, tt := range tests { //nolint:golint,paralleltest
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			TimeFactor = nil
 			defer os.Remove(*tt.args.filename)

--- a/tools/eventlist/pkg/xml/scvd/scvd.go
+++ b/tools/eventlist/pkg/xml/scvd/scvd.go
@@ -21,6 +21,7 @@ package scvd
 import (
 	"encoding/xml"
 	"eventlist/pkg/eval"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -219,6 +220,9 @@ func getOne(filename *string, events Events, typedefs eval.Typedefs) error {
 					members[member.Name] = mem
 				}
 				if len(members) > 0 {
+					if typedef.Size > math.MaxUint32 {
+						return eval.ErrEof
+					}
 					typedefs[typedef.Name] = eval.ITypedef{Size: uint32(typedef.Size), BigEndian: typedef.Endian == "B" || typedef.Endian == "b", Members: members}
 				}
 			}

--- a/tools/eventlist/pkg/xml/scvd/scvd.go
+++ b/tools/eventlist/pkg/xml/scvd/scvd.go
@@ -221,7 +221,7 @@ func getOne(filename *string, events Events, typedefs eval.Typedefs) error {
 				}
 				if len(members) > 0 {
 					if typedef.Size > math.MaxUint32 {
-						return eval.ErrEof
+						return eval.ErrRange
 					}
 					typedefs[typedef.Name] = eval.ITypedef{Size: uint32(typedef.Size), BigEndian: typedef.Endian == "B" || typedef.Endian == "b", Members: members}
 				}

--- a/tools/eventlist/pkg/xml/scvd/scvd_test.go
+++ b/tools/eventlist/pkg/xml/scvd/scvd_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-//nolint:golint,paralleltest
+//nolint:paralleltest
 package scvd
 
 import (


### PR DESCRIPTION
- This change updates the Go version and the GitHub Actions versions. After the updates, the newer linter reported several additional findings, which have also been addressed in this change.
- Dropped darwin amd64 support


**_Please note that the linter fixes were generated with AI assistance._**